### PR TITLE
Add SnapPDF to alternatives.md

### DIFF
--- a/docs/alternatives.md
+++ b/docs/alternatives.md
@@ -1,12 +1,13 @@
 ---
 title: Alternatives
-weight: 5
+weight: 6
 ---
 
 Laravel PDF uses Chrome Headless to generate PDFs. This is a great solution for most use cases. You can use any CSS you want, and it will be rendered correctly. However, generating a PDF this way can be resource intensive.
 
 If you don't like the trade-off mentioned above, here are some alternatives to generate PDFs:
 
+- [SnapPDF](https://github.com/beganovich/snappdf) - Convert webpages or HTML into the PDF file using Chromium-powered browsers. It communicates directly with browser itself and it takes less than .5s to generate PDFs (with cold start).
 - [laravel-dompdf](https://github.com/barryvdh/laravel-dompdf) - A DOMPDF Wrapper for Laravel
 - [wkhtmltopdf](http://wkhtmltopdf.org/) - A command line tool to render HTML into PDF and various image formats using the QT Webkit rendering engine. This is the engine used behind the scenes in Snappy.
 - [mPDF](http://www.mpdf1.com/mpdf/index.php) - A PHP class to generate PDF files from HTML with Unicode/UTF-8 and CJK support.


### PR DESCRIPTION
This PR updates the docs by adding [SnapPDF](https://github.com/beganovich/snappdf) to the list of alternatives. SnapPDF converts webpages or HTML into the PDF file using Chromium-powered browsers. 

**_From SnapPDF Docs:_**
> Main benefit and reason why this library exists is the speed of generating PDFs. It communicates directly with browser itself and it takes less than .5s to generate PDFs (with cold start). This was tested on mid-range laptop with i5-5300U and average SSD.