### PR TITLE
fix(functions): allow calling `pdf` without argument

### DIFF
--- a/src/Support/functions.php
+++ b/src/Support/functions.php
@@ -5,7 +5,7 @@ namespace Spatie\LaravelPdf\Support;
 use Spatie\LaravelPdf\Facades\Pdf;
 use Spatie\LaravelPdf\PdfBuilder;
 
-function pdf(string $viewPath, array $data = []): PdfBuilder
+function pdf(string $viewPath = '', array $data = []): PdfBuilder
 {
     return Pdf::view($viewPath, $data);
 }

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use Spatie\LaravelPdf\Facades\Pdf;
+use Spatie\LaravelPdf\FakePdfBuilder;
+use Spatie\LaravelPdf\PdfBuilder;
+
+use function Spatie\LaravelPdf\Support\pdf;
+
+test('the `pdf` function returns the pdf builder instance', function () {
+    expect(pdf())->toBeInstanceOf(PdfBuilder::class);
+});
+
+test('the `pdf` function respect fakes', function () {
+    Pdf::fake();
+
+    expect(pdf())->toBeInstanceOf(FakePdfBuilder::class);
+});
+
+test('the `pdf` function accepts a view and parameters', function () {
+    Pdf::fake();
+
+    expect(pdf('foo', ['bar' => 'bax']))
+        ->toBeInstanceOf(FakePdfBuilder::class)
+        ->viewName->toBe('foo')
+        ->viewData->toBe(['bar' => 'bax']);
+});


### PR DESCRIPTION
This pull request updates the `pdf` function so it can be called without having to specify a view. This usage is currently [documented](https://spatie.be/docs/laravel-pdf/v1/introduction) but not supported.

I also added a few tests.