### PR TITLE
Introduce a new `Pdf` class API

### DIFF
--- a/src/Commands/PdfMakeCommand.php
+++ b/src/Commands/PdfMakeCommand.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Spatie\LaravelPdf\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Foundation\Inspiring;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Input\InputOption;
+
+#[AsCommand(name: 'make:pdf')]
+class PdfMakeCommand extends GeneratorCommand
+{
+    protected $name = 'make:pdf';
+
+    protected $description = 'Create a new PDF class.';
+
+    protected $type = 'PDF';
+
+    public function handle()
+    {
+        if (parent::handle() === false && ! $this->option('force')) {
+            return false;
+        }
+
+        $this->writeView();
+    }
+
+    protected function writeView(): void
+    {
+        $path = $this->viewPath(
+            str_replace('.', '/', 'pdf.' . $this->getView()) . '.blade.php'
+        );
+
+        if (!$this->files->isDirectory(dirname($path))) {
+            $this->files->makeDirectory(dirname($path), 0777, true, true);
+        }
+
+        if ($this->files->exists($path) && !$this->option('force')) {
+            $this->components->error('View already exists.');
+
+            return;
+        }
+
+        file_put_contents(
+            $path,
+            '<div>
+    <!-- ' . Inspiring::quotes()->random() . ' -->
+</div>'
+        );
+    }
+
+    protected function buildClass($name)
+    {
+        return str_replace(
+            '{{ view }}',
+            'view(\'pdf.' . $this->getView() . '\')',
+            parent::buildClass($name)
+        );
+    }
+
+    protected function getView(): string
+    {
+        $name = str_replace('\\', '/', $this->argument('name'));
+
+        return collect(explode('/', $name))
+            ->map(function ($part) {
+                return Str::kebab($part);
+            })
+            ->implode('.');
+    }
+
+    protected function getStub()
+    {
+        return $this->resolveStubPath('/stubs/pdf.stub');
+    }
+
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+            ? $customPath
+            : __DIR__ . '/../..' . $stub;
+    }
+
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace . '\Pdf';
+    }
+
+    protected function getOptions()
+    {
+        return [
+            ['force', 'f', InputOption::VALUE_NONE, 'Create the class even if the PDF already exists'],
+        ];
+    }
+}

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -13,7 +13,7 @@ use Spatie\LaravelPdf\Enums\Orientation;
 
 abstract class Pdf extends Component implements Responsable, Htmlable
 {
-    protected ?Builder $builder = null;
+    protected ?PdfBuilder $builder = null;
 
     public function getPdfBuilder(): PdfBuilder
     {
@@ -98,5 +98,14 @@ abstract class Pdf extends Component implements Responsable, Htmlable
     public function toResponse($request)
     {
         return $this->getPdfBuilder()->toResponse($request);
+    }
+
+    public static function test(...$args): TestablePdf
+    {
+        Builder::fake();
+
+        $pdf = new static(...$args);
+
+        return new TestablePdf($pdf->getPdfBuilder());
     }
 }

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -7,12 +7,87 @@ use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Support\Facades\Blade;
 use Spatie\LaravelPdf\Facades\Pdf as Builder;
 use Illuminate\View\Component;
+use Illuminate\View\View;
+use Spatie\LaravelPdf\Enums\Format;
+use Spatie\LaravelPdf\Enums\Orientation;
 
 abstract class Pdf extends Component implements Responsable, Htmlable
 {
+    protected ?Builder $builder = null;
+
     public function getPdfBuilder(): PdfBuilder
     {
-        return Builder::html($this->toHtml());
+        return $this->builder ??= Builder::html($this->toHtml())
+            ->when($this->name(), fn (Builder $builder, string $name) => $builder->name($name))
+            ->when($this->header(), fn (Builder $builder, View | Htmlable | string $header) => $builder->headerHtml(match (true) {
+                $header instanceof View => $header->render(),
+                $header instanceof Htmlable => $header->toHtml(),
+                default => $header,
+            }))
+            ->when($this->footer(), fn (Builder $builder, View | Htmlable | string $footer) => $builder->footerHtml(match (true) {
+                $footer instanceof View => $footer->render(),
+                $footer instanceof Htmlable => $footer->toHtml(),
+                default => $footer,
+            }))
+            ->when($this->format(), fn (Builder $builder, Format | string $format) => $builder->format($format))
+            ->when($this->disk(), fn (Builder $builder, string $disk) => $builder->disk($disk))
+            ->orientation($this->orientation());
+    }
+
+    public function header(): View | Htmlable | string | null
+    {
+        return null;
+    }
+
+    public function footer(): View | Htmlable | string | null
+    {
+        return null;
+    }
+
+    public function orientation(): Orientation | string
+    {
+        return Orientation::Portrait;
+    }
+
+    public function format(): Format | string | null
+    {
+        return null;
+    }
+
+    public function name(): ?string
+    {
+        return null;
+    }
+
+    public function download(?string $downloadName = null): static
+    {
+        $this->getPdfBuilder()->download($downloadName ?? $this->name());
+
+        return $this;
+    }
+
+    public function inline(?string $downloadName = null): static
+    {
+        $this->getPdfBuilder()->inline($downloadName ?? $this->name());
+
+        return $this;
+    }
+
+    public function save(string $path): static
+    {
+        $this->getPdfBuilder()->save($path);
+
+        return $this;
+    }
+
+    public function disk(): ?string
+    {
+        return null;
+    }
+
+    public function base64(): string
+    {
+        return $this->getPdfBuilder()->base64();
     }
 
     public function toHtml()

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Spatie\LaravelPdf;
+
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Contracts\Support\Responsable;
+use Illuminate\Support\Facades\Blade;
+use Spatie\LaravelPdf\Facades\Pdf as Builder;
+use Illuminate\View\Component;
+
+abstract class Pdf extends Component implements Responsable, Htmlable
+{
+    public function getPdfBuilder(): PdfBuilder
+    {
+        return Builder::html($this->toHtml());
+    }
+
+    public function toHtml()
+    {
+        return Blade::renderComponent($this);
+    }
+
+    public function toResponse($request)
+    {
+        return $this->getPdfBuilder()->toResponse($request);
+    }
+}

--- a/src/PdfBuilder.php
+++ b/src/PdfBuilder.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Traits\Conditionable;
 use Spatie\Browsershot\Browsershot;
 use Spatie\LaravelPdf\Enums\Format;
 use Spatie\LaravelPdf\Enums\Orientation;
@@ -14,6 +15,8 @@ use Wnx\SidecarBrowsershot\BrowsershotLambda;
 
 class PdfBuilder implements Responsable
 {
+    use Conditionable;
+
     public string $viewName = '';
 
     public array $viewData = [];

--- a/src/PdfServiceProvider.php
+++ b/src/PdfServiceProvider.php
@@ -10,7 +10,11 @@ class PdfServiceProvider extends PackageServiceProvider
 {
     public function configurePackage(Package $package): void
     {
-        $package->name('laravel-pdf');
+        $package
+            ->name('laravel-pdf')
+            ->hasCommands([
+                Commands\PdfMakeCommand::class,
+            ]);
     }
 
     public function bootingPackage()

--- a/src/TestablePdf.php
+++ b/src/TestablePdf.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Spatie\LaravelPdf;
+
+/**
+ * @mixin \Spatie\LaravelPdf\FakePdfBuilder
+ */
+class TestablePdf
+{
+    public function __construct(
+        protected FakePdfBuilder $fake,
+    ) {
+        $this->fake->save('');
+    }
+
+    public function __call(string $method, array $args): static
+    {
+        $this->fake->{$method}(...$args);
+
+        return $this;
+    }
+}

--- a/stubs/pdf.stub
+++ b/stubs/pdf.stub
@@ -1,0 +1,20 @@
+<?php
+
+namespace {{ namespace }};
+
+use Closure;
+use Illuminate\Contracts\View\View;
+use Spatie\LaravelPdf\Pdf;
+
+class {{ class }} extends Pdf
+{
+    public function __construct()
+    {
+        //
+    }
+
+    public function render(): View|Closure|string
+    {
+        return {{ view }};
+    }
+}

--- a/tests/TestablePdfTest.php
+++ b/tests/TestablePdfTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use Spatie\LaravelPdf\Pdf;
+
+it('can be used to test Pdf classes', function () {
+    ExamplePdf::test()
+        ->assertSee('Hello, Spatie!');
+});
+
+class ExamplePdf extends Pdf
+{
+    public function __construct(
+        public string $user = 'Spatie',
+    ) {}
+
+    public function render()
+    {
+        return <<<'BLADE'
+            Hello, {{ $user }}!
+        BLADE;
+    }
+}


### PR DESCRIPTION
The goal of this pull request is to introduce a new dedicated `Pdf` class API that can be used to return object-based PDFs to the browser, etc.

Using Blade component classes as the basis for rendering, etc, it allows you to do something like the following:

```php
class Invoice extends Pdf
{
	public function __construct(
		public Order $order,
	) {}

	public function render(): View
	{
		return view('pdf.invoice');
	}
}
```

Then inside of a route, do something similar to this:

```php
Route::get('/orders/{order}/invoice', function (Order $order) {
	return new Invoice($order);
});
```

The `Pdf` class is `Responsable` and defers the logic of that to the underlying `PdfBuilder`. To extend the default configuration of the `PdfBuilder`, you can overwrite the `getPdfBuilder()` method and call extra methods where necessary.

I'm opening this as a draft initially to get some feedback, but also because I need to write tests still. Things I'd like feedback on:
1. Is this a good idea? (my thoughts are below)
2. Should we have empty/carcass methods on the `Pdf` class to do things such as `header()`, `footer()`, `disk()`, `name()`, etc and then just configure the `PdfBuilder` using those methods?
3. Should we also extend the testing API to work with dedicated `Pdf` classes so that you can easily test them, i.e.
```php
Invoice::test($order)
	->assertSee(...)
	->etc()
```

Having worked on lots of applications that need PDFs, I've found myself implementing this sort of API quite a few times and having it as part of this package will a) allow me to depend only on this package in the future and b) provide a nicer, abstracted API for building re-usable PDFs, without needing to write the same `Pdf::view(...)->...` chains.