### PR TITLE
add header and footer aliases

### DIFF
--- a/src/PdfBuilder.php
+++ b/src/PdfBuilder.php
@@ -68,6 +68,11 @@ class PdfBuilder implements Responsable
         return $this;
     }
 
+    public function header(string $view, array $data = []): self
+    {
+        return $this->headerView($view, $data);
+    }
+
     public function footerView(string $view, array $data = []): self
     {
         $this->footerViewName = $view;
@@ -75,6 +80,11 @@ class PdfBuilder implements Responsable
         $this->footerData = $data;
 
         return $this;
+    }
+
+    public function footer(string $view, array $data = []): self
+    {
+        return $this->footerView($view, $data);
     }
 
     public function landscape(): self


### PR DESCRIPTION
Checking the docs I see some places where the method `footer` is treated like the `footerView` method, as this method does not exist, and it looks pretty natural to chain methods in this way I added an alias for the header and another for footer.

It allows anyone to follow the docs without any breaking code.