### PR TITLE
Added showBackground() by default into getBrowsershot() function. 

### DIFF
--- a/src/PdfBuilder.php
+++ b/src/PdfBuilder.php
@@ -293,6 +293,8 @@ class PdfBuilder implements Responsable
 
         $browsershot = $browsershotClass::html($this->getHtml());
 
+        $browsershot->showBackground();
+
         $headerHtml = $this->getHeaderHtml();
 
         $footerHtml = $this->getFooterHtml();


### PR DESCRIPTION
Issue: Background colours aren't supported by default. 

This can be overcome by setting

`withBrowsershot(function (Browsershot $browsershot) {
            $browsershot->showBackground();
        })`

however it should be enabled by default for the use case of this package.