### PR TITLE
Add ->paperSize()-method

### DIFF
--- a/docs/basic-usage/formatting-pdfs.md
+++ b/docs/basic-usage/formatting-pdfs.md
@@ -92,11 +92,10 @@ If you don't want to use standardized formats, you can also change this by calli
 
 ```php
 use Spatie\LaravelPdf\Facades\Pdf;
-use Spatie\LaravelPdf\Enums\Format;
 
 Pdf::view('pdf.receipt', ['order' => $order])
     ->paperSize(57, 500, 'mm')
-    ->save('/some/directory/receipt-4912941.pdf');
+    ->save('/some/directory/receipt-12345.pdf');
 ```
 
 ### Page margins

--- a/docs/basic-usage/formatting-pdfs.md
+++ b/docs/basic-usage/formatting-pdfs.md
@@ -86,6 +86,19 @@ A5: 5.83in  x  8.27in
 A6: 4.13in  x  5.83in
 ```
 
+### Paper size
+
+If you don't want to use standardized formats, you can also change this by calling the `paperSize` method instead.
+
+```php
+use Spatie\LaravelPdf\Facades\Pdf;
+use Spatie\LaravelPdf\Enums\Format;
+
+Pdf::view('pdf.receipt', ['order' => $order])
+    ->paperSize(57, 500, 'mm')
+    ->save('/some/directory/receipt-4912941.pdf');
+```
+
 ### Page margins
 
 Margins can be set using the `margins` method. The unit of the margins is millimeters by default.

--- a/src/PdfBuilder.php
+++ b/src/PdfBuilder.php
@@ -203,6 +203,15 @@ class PdfBuilder implements Responsable
         return $this;
     }
 
+    public function paperSize(float $width, float $height, string $unit = 'mm'): self
+    {
+        $this->withBrowsershot(function (Browsershot $browsershot) use ($width, $height, $unit) {
+            $browsershot->paperSize($width, $height, $unit);
+        });
+
+        return $this;
+    }
+
     public function withBrowsershot(callable $callback): self
     {
         $this->customizeBrowsershot = $callback;

--- a/tests/PdfTest.php
+++ b/tests/PdfTest.php
@@ -106,6 +106,16 @@ it('can accept the paper format', function () {
         ->toContainText('This is a test');
 });
 
+it('can accept the page size', function () {
+    Pdf::view('test')
+        ->paperSize(200, 400, 'mm')
+        ->save($this->targetPath);
+
+    expect($this->targetPath)
+        ->toHaveDimensions(567, 1134)
+        ->toContainText('This is a test');
+});
+
 it('can accept the orientation', function () {
     Pdf::view('test')
         ->orientation(Orientation::Landscape)


### PR DESCRIPTION
As promised in https://github.com/spatie/laravel-pdf/discussions/18#discussioncomment-8109898

This PR adds a paperSize()-method on the [PdfBuilder](https://github.com/spatie/laravel-pdf/pull/33/files#diff-1b56e1ee5c733f35b863a3c97e251d4313c9e3b20177ae136ce8b8fea22f13ea). Also [wrote a test](https://github.com/spatie/laravel-pdf/pull/33/files#diff-9994c319899100025d7a783c15182aedc9c37dc78e79cfe1cf0ed4f79d7f3c48) and [added an example to the docs](https://github.com/spatie/laravel-pdf/pull/33/files#diff-368d752379b2ee4383766df63fe8ce2e847d40e7d6016d761aea2aa9480e157f).

```php
use Spatie\LaravelPdf\Facades\Pdf;

Pdf::view('pdf.receipt', ['order' => $order])
 ->paperSize(57, 500, 'mm')
 ->save('/some/directory/receipt-12345.pdf');
```