### PR TITLE
Modify break statement in FakePdfBuilder.

### DIFF
--- a/src/FakePdfBuilder.php
+++ b/src/FakePdfBuilder.php
@@ -112,7 +112,7 @@ class FakePdfBuilder extends PdfBuilder
         foreach ($this->savedPdfs as $savedPdf) {
             foreach ($text as $singleText) {
                 if (! str_contains($savedPdf['pdf']->html, $singleText)) {
-                    break 2; // jump out of if branch and the inner foreach loop
+                    break; // jump out of the inner foreach loop
                 }
             }
 


### PR DESCRIPTION
`break` is not interrupt `if`, only `foreach`, `for`, `switch`... https://www.php.net/manual/en/control-structures.break.php Because of this mistake behaviour of `assertSee` function was wrong.