### PR TITLE
fix default paper format in docs

### DIFF
--- a/docs/basic-usage/formatting-pdfs.md
+++ b/docs/basic-usage/formatting-pdfs.md
@@ -88,7 +88,7 @@ Pdf::view('pdf.invoice', ['invoice' => $invoice])
 
 ## Paper format
 
-By default, all PDFs are created in A4 format. You can change this by calling the `format` method.
+By default, all PDFs are created in Letter format. You can change this by calling the `format` method.
 
 ```php
 use Spatie\LaravelPdf\Facades\Pdf;

--- a/tests/DefaultPdfTest.php
+++ b/tests/DefaultPdfTest.php
@@ -21,6 +21,12 @@ it('can set defaults for pdfs', function () {
         ->toContainText('test');
 });
 
+it('defaults to the letter format', function () {
+    Pdf::view('test')->save($this->targetPath);
+
+    expect($this->targetPath)->toHaveDimensions(612, 792);
+});
+
 it('will not use properties of the previous pdf when not setting a default', function () {
     $firstPath = getTempPath('first.pdf');
     Pdf::html('test')

--- a/tests/PdfTest.php
+++ b/tests/PdfTest.php
@@ -147,7 +147,7 @@ it('will use a fresh instance after saving', function () {
     expect(getTempPath('first.pdf'))
         ->toHaveDimensions(792, 612);
 
-    // second pdf is landscape
+    // second pdf is portrait
     expect(getTempPath('second.pdf'))
         ->toHaveDimensions(612, 792);
 });


### PR DESCRIPTION
The [docs](https://spatie.be/docs/laravel-pdf/v1/basic-usage/formatting-pdfs) claim that the default paper format is A4. This is apparently not the case, as it is set to US Letter by default.

Note: Going through the existing tests I also spotted a `landscape` which should probably be `portrait`.