### PR TITLE
PDFBuilder now honours pdf name set by either name() or download() methods during download

### DIFF
--- a/src/PdfBuilder.php
+++ b/src/PdfBuilder.php
@@ -137,7 +137,7 @@ class PdfBuilder implements Responsable
 
     public function download(?string $downloadName = null): self
     {
-        $this->name($downloadName ?? 'download');
+        $this->downloadName ?? $this->name($downloadName ?? 'download');
 
         $this->addHeaders([
             'Content-Type' => 'application/pdf',

--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -24,3 +24,43 @@ test('the `pdf` function accepts a view and parameters', function () {
         ->viewName->toBe('foo')
         ->viewData->toBe(['bar' => 'bax']);
 });
+
+test('the `pdf` function name accepts a name parameter and sets downloadName', function () {
+    Pdf::fake();
+
+    expect(pdf('foo', ['bar' => 'bax'])->name('baz.pdf'))
+        ->toBeInstanceOf(FakePdfBuilder::class)
+        ->viewName->toBe('foo')
+        ->viewData->toBe(['bar' => 'bax'])
+        ->downloadName->toBe('baz.pdf');
+});
+
+test('the `pdf` function download accepts a name parameter and sets downloadName', function () {
+    Pdf::fake();
+
+    expect(pdf('foo', ['bar' => 'bax'])->download('baz.pdf'))
+        ->toBeInstanceOf(FakePdfBuilder::class)
+        ->viewName->toBe('foo')
+        ->viewData->toBe(['bar' => 'bax'])
+        ->downloadName->toBe('baz.pdf');
+});
+
+test('the `pdf` function name accepts a name parameter and sets downloadName while calling download', function () {
+    Pdf::fake();
+
+    expect(pdf('foo', ['bar' => 'bax'])->name('baz.pdf')->download())
+        ->toBeInstanceOf(FakePdfBuilder::class)
+        ->viewName->toBe('foo')
+        ->viewData->toBe(['bar' => 'bax'])
+        ->downloadName->toBe('baz.pdf');
+});
+
+test('the `pdf` function download assigns the default to downloadName when no name is specified', function () {
+    Pdf::fake();
+
+    expect(pdf('foo', ['bar' => 'bax'])->download())
+        ->toBeInstanceOf(FakePdfBuilder::class)
+        ->viewName->toBe('foo')
+        ->viewData->toBe(['bar' => 'bax'])
+        ->downloadName->toBe('download.pdf');
+});


### PR DESCRIPTION
Updated PDFBuilder function to first check whether pdf name has been set, if not it uses the name parameter from download. If download name parameter is empty default name is used.

Added tests to assert changes don't break current name and download functionality