### PR TITLE
Fix setting the name via download()

### DIFF
--- a/src/PdfBuilder.php
+++ b/src/PdfBuilder.php
@@ -137,7 +137,7 @@ class PdfBuilder implements Responsable
 
     public function download(?string $downloadName = null): self
     {
-        $this->downloadName ?? $this->name($downloadName ?? 'download');
+        $this->downloadName ?: $this->name($downloadName ?? 'download');
 
         $this->addHeaders([
             'Content-Type' => 'application/pdf',


### PR DESCRIPTION
We had a test like this that was failing after updating to 1.5: 
```php
 Pdf::assertRespondedWithPdf(fn (PdfBuilder $pdf) => $pdf->downloadName === $invoice->filename));
```

The reason being that `$pdf->downloadName` is still an empty string, despite calling `->download($invoice->filename)` in the controller. 

I believe this fixes #138. 

Oddly enough some tests including `the pdf function download accepts a name parameter and sets downloadName` failed on the old implementation, so not sure how that one got through 🤷‍♂️