### PR TITLE
Make getBrowsershot public

### DIFF
--- a/src/PdfBuilder.php
+++ b/src/PdfBuilder.php
@@ -313,7 +313,7 @@ class PdfBuilder implements Responsable
         ]);
     }
 
-    protected function getBrowsershot(): Browsershot
+    public function getBrowsershot(): Browsershot
     {
         $browsershotClass = $this->onLambda
             ? BrowsershotLambda::class


### PR DESCRIPTION
Working with big PDFs on Lambda can lead to maximum payload errors, as lambda limits to 6MB or 8MB...

Making this method public we can easily call it with and then call `saveToS3` from `BrowserShotLambda`.

Besides that we could also improve support to saveOnDisk in case it's s3 driver, use this method directly to avoid downloading the file to the machine and saving directly there.