### PR TITLE
Add scale option to configure the pdf being generated

### DIFF
--- a/src/PdfBuilder.php
+++ b/src/PdfBuilder.php
@@ -38,6 +38,8 @@ class PdfBuilder implements Responsable
 
     public ?array $paperSize = null;
 
+    public ?float $scale = null;
+
     public ?string $orientation = null;
 
     public ?array $margins = null;
@@ -220,6 +222,13 @@ class PdfBuilder implements Responsable
         return $this;
     }
 
+    public function scale(float $scale): self
+    {
+        $this->scale = $scale;
+
+        return $this;
+    }
+
     public function withBrowsershot(callable $callback): self
     {
         $this->customizeBrowsershot = $callback;
@@ -357,6 +366,10 @@ class PdfBuilder implements Responsable
 
         if ($this->paperSize) {
             $browsershot->paperSize(...$this->paperSize);
+        }
+
+        if ($this->scale) {
+            $browsershot->scale($this->scale);
         }
 
         if ($this->orientation === Orientation::Landscape->value) {


### PR DESCRIPTION
#183 

Browsershot is having the option to scale the pdf, and it's not extended to this package.
A simple scale option is added, I think it will be useful to many people who are using this package too.

Currently it can only achieved by customizeBrowsershot.
Which isn't quite ideal.

Let me know if there's anything missing or needed to complete this additional configuration for this package.
🙌 

Thanks for the amazing package!!