### PR TITLE
add assertDontSee test method

### DIFF
--- a/src/FakePdfBuilder.php
+++ b/src/FakePdfBuilder.php
@@ -4,6 +4,7 @@ namespace Spatie\LaravelPdf;
 
 use Closure;
 use Illuminate\Http\Response;
+use Illuminate\Support\Arr;
 use PHPUnit\Framework\Assert;
 
 class FakePdfBuilder extends PdfBuilder
@@ -105,27 +106,24 @@ class FakePdfBuilder extends PdfBuilder
 
     public function assertSee(string|array $text): void
     {
-        if (is_string($text)) {
-            $text = [$text];
-        }
+        $values = Arr::wrap($text);
 
-        foreach ($this->savedPdfs as $savedPdf) {
-            foreach ($text as $singleText) {
-                if (! str_contains($savedPdf['pdf']->html, $singleText)) {
-                    break 2; // jump out of the inner foreach loop
-                }
+        foreach ($values as $value) {
+            foreach ($this->savedPdfs as $savedPdf) {
+                Assert::assertStringContainsString((string) $value, $savedPdf['pdf']->html);
             }
-
-            $this->markAssertionPassed();
-
-            return;
         }
+    }
 
-        $texts = collect($text)
-            ->wrap('`')
-            ->join(',', ', and ');
+    public function assertDontSee(string|array $text): void
+    {
+        $values = Arr::wrap($text);
 
-        Assert::fail("Did not save a PDF that contains {$texts}");
+        foreach ($values as $value) {
+            foreach ($this->savedPdfs as $savedPdf) {
+                Assert::assertStringNotContainsString((string) $value, $savedPdf['pdf']->html);
+            }
+        }
     }
 
     public function assertRespondedWithPdf(Closure $expectations): void

--- a/src/FakePdfBuilder.php
+++ b/src/FakePdfBuilder.php
@@ -106,22 +106,22 @@ class FakePdfBuilder extends PdfBuilder
 
     public function assertSee(string|array $text): void
     {
-        $values = Arr::wrap($text);
+        $strings = Arr::wrap($text);
 
-        foreach ($values as $value) {
+        foreach ($strings as $string) {
             foreach ($this->savedPdfs as $savedPdf) {
-                Assert::assertStringContainsString((string) $value, $savedPdf['pdf']->html);
+                Assert::assertStringContainsString((string) $string, $savedPdf['pdf']->html);
             }
         }
     }
 
     public function assertDontSee(string|array $text): void
     {
-        $values = Arr::wrap($text);
+        $strings = Arr::wrap($text);
 
-        foreach ($values as $value) {
+        foreach ($strings as $string) {
             foreach ($this->savedPdfs as $savedPdf) {
-                Assert::assertStringNotContainsString((string) $value, $savedPdf['pdf']->html);
+                Assert::assertStringNotContainsString((string) $string, $savedPdf['pdf']->html);
             }
         }
     }

--- a/tests/FakePdfTest.php
+++ b/tests/FakePdfTest.php
@@ -77,6 +77,47 @@ it('can determine that the pdf content does not contain multiple strings', funct
     ]);
 })->fails();
 
+it('can determine that the pdf content does not contain a unexpected string', function () {
+    Pdf::view('test')->save('my-custom-name.pdf');
+
+    Pdf::assertDontSee('this-string-does-not-exist');
+});
+
+it('can determine that the pdf content contains a expected string', function () {
+    Pdf::view('test')->save('my-custom-name.pdf');
+
+    Pdf::assertDontSee('test');
+})->fails();
+
+it('can determine that the pdf content does not contain multiple unexpected strings', function () {
+    Pdf::view('test')->save('my-custom-name.pdf');
+
+    Pdf::assertDontSee([
+        'this-string-is-not-present-in-the-pdf',
+        'this-string-is-not-present-in-the-pdf-as-well',
+        'this-string-is-not-present-in-the-pdf-either',
+    ]);
+});
+
+it('can determine that the pdf content contains multiple expected strings', function () {
+    Pdf::view('test')->save('my-custom-name.pdf');
+
+    Pdf::assertDontSee([
+        'This',
+        'test',
+    ]);
+})->fails();
+
+it('can determine that the pdf content contain an unexpected string between expected strings', function () {
+    Pdf::view('test')->save('my-custom-name.pdf');
+
+    Pdf::assertDontSee([
+        'this',
+        'this-string-is-not-present-in-the-pdf',
+        'test',
+    ]);
+})->fails();
+
 it('can determine that a pdf was saved a a certain path', function () {
     Pdf::view('test')->save('my-custom-name.pdf');
 


### PR DESCRIPTION
add assertDontSee test method, plus tests with small refactor

I was recently using this package and had an instance where if a condition was true I needed to remove two icons on my pdf, to test this I had to write an assertSee then see if that test failed. Thought it would've been cleaner to have an assertDontSee method