### PR TITLE
update contributing link as no CONTRIBUTING.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed re
 
 ## Contributing
 
-Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
+Please see [CONTRIBUTING](https://github.com/spatie/.github/blob/main/CONTRIBUTING.md) for details.
 
 ## Security Vulnerabilities
 


### PR DESCRIPTION
Noticed the contributing.md file didn't exist, changed it to https://github.com/spatie/.github/blob/main/CONTRIBUTING.md where other spatie repos are pointing to