### PR TITLE
Fix inconsistent behavior in save() method when using vs not using a disk

### DIFF
--- a/tests/PdfTest.php
+++ b/tests/PdfTest.php
@@ -157,3 +157,22 @@ it('will execute javascript', function () {
 
     expect($this->targetPath)->toContainText('hello');
 });
+
+it('can save as png in local and disk', function () {
+    Storage::fake('local');
+
+    $firstPath = getTempPath('first.png');
+    Pdf::view('test')
+        ->save($firstPath);
+
+    expect(mime_content_type($firstPath))
+        ->toBe('image/png');
+
+    Pdf::view('test')
+        ->disk('local')
+        ->save('second.png');
+
+    expect(Storage::disk('local')
+        ->mimeType('second.png'))
+        ->toBe('image/png');
+});


### PR DESCRIPTION
Currently, the save() function behaves slightly differently when using a disk versus not using one. This PR resolves the inconsistency by creating a temporary file during saving.

Example of the issue:

```php
Pdf::view('invoice')->save('invoice.png'); // Saves a PNG file

Pdf::view('invoice')->disk('s3')->save('invoice.png'); // Saves a PDF file
```

Using ```$fileName``` instead of ```$path``` directly to avoid any errors when saving to a full path.