### PR TITLE
feat: Add Macroable trait to PdfBuilder class

### DIFF
--- a/docs/advanced-usage/extending-with-macros.md
+++ b/docs/advanced-usage/extending-with-macros.md
@@ -1,0 +1,44 @@
+---
+title: Extending with Macros
+weight: 6
+---
+
+The `PdfBuilder` class is macroable, which means you can add custom methods to it using Laravel's macro functionality. This allows you to extend the PDF builder with your own custom methods.
+
+## Adding macros
+
+You can add macros to the `PdfBuilder` class in your service provider's `boot` method:
+
+```php
+use Spatie\LaravelPdf\PdfBuilder;
+
+class AppServiceProvider extends ServiceProvider
+{
+    public function boot()
+    {
+        PdfBuilder::macro('withCustomHeader', function (string $title) {
+            $this->headerHtml = "<h1>{$title}</h1>";
+
+            return $this;
+        });
+    }
+}
+```
+
+## Using macros
+
+Once you've added a macro, you can use it just like any other method on the `PdfBuilder` class:
+
+```php
+use Spatie\LaravelPdf\Facades\Pdf;
+
+Pdf::view('invoice')
+    ->withCustomHeader('Invoice #123')
+    ->save('invoice.pdf');
+```
+
+Macros are particularly useful for:
+
+-   Adding organization-specific formatting options
+-   Creating reusable PDF components
+-   Standardizing your PDF outputs across your application

--- a/src/PdfBuilder.php
+++ b/src/PdfBuilder.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Traits\Macroable;
 use Spatie\Browsershot\Browsershot;
 use Spatie\LaravelPdf\Enums\Format;
 use Spatie\LaravelPdf\Enums\Orientation;
@@ -15,6 +16,8 @@ use Wnx\SidecarBrowsershot\BrowsershotLambda;
 
 class PdfBuilder implements Responsable
 {
+    use Macroable;
+
     public string $viewName = '';
 
     public array $viewData = [];


### PR DESCRIPTION
This PR makes the `PdfBuilder `class macroable, allowing users to add their own custom methods.

I've added:
- `Macroable `trait to `PdfBuilder`
- Documentation with examples in the advanced usage section

This change follows Laravel conventions where key components support extension through macros.
