### PR TITLE
feat: add configuration support for browsershot binary paths

### DIFF
--- a/config/laravel-pdf.php
+++ b/config/laravel-pdf.php
@@ -1,0 +1,43 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Browsershot Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you can configure default Browsershot settings that will be applied
+    | to all PDF generation. These settings can still be overridden using the
+    | withBrowsershot() method on individual PDF instances.
+    |
+    */
+
+    'browsershot' => [
+        /*
+        |--------------------------------------------------------------------------
+        | Binary Paths
+        |--------------------------------------------------------------------------
+        |
+        | Configure the paths to Node.js, npm, Chrome, and other binaries.
+        | Leave null to use system defaults or Browsershot's auto-detection.
+        |
+        */
+        'node_binary' => env('LARAVEL_PDF_NODE_BINARY'),
+        'npm_binary' => env('LARAVEL_PDF_NPM_BINARY'),
+        'include_path' => env('LARAVEL_PDF_INCLUDE_PATH'),
+        'chrome_path' => env('LARAVEL_PDF_CHROME_PATH'),
+        'node_modules_path' => env('LARAVEL_PDF_NODE_MODULES_PATH'),
+        'bin_path' => env('LARAVEL_PDF_BIN_PATH'),
+        'temp_path' => env('LARAVEL_PDF_TEMP_PATH'),
+
+        /*
+        |--------------------------------------------------------------------------
+        | Additional Options
+        |--------------------------------------------------------------------------
+        |
+        | Other Browsershot configuration options.
+        |
+        */
+        'write_options_to_file' => env('LARAVEL_PDF_WRITE_OPTIONS_TO_FILE', false),
+    ],
+];

--- a/docs/advanced-usage/configuration.md
+++ b/docs/advanced-usage/configuration.md
@@ -1,0 +1,71 @@
+---
+title: Configuration
+weight: 1
+---
+
+Laravel PDF supports configuration-based customization of Browsershot settings, allowing you to set default options that apply to all PDF generation in your application.
+
+## Publishing the Configuration File
+
+To publish the configuration file, run:
+
+```bash
+php artisan vendor:publish --tag=laravel-pdf-config
+```
+
+This will create a `config/laravel-pdf.php` file in your application.
+
+## Configuration Options
+
+The configuration file provides several sections for customizing Browsershot behavior:
+
+### Binary Paths
+
+Configure paths to Node.js, npm, Chrome, and other binaries:
+
+```php
+'browsershot' => [
+    'node_binary' => env('LARAVEL_PDF_NODE_BINARY'),
+    'npm_binary' => env('LARAVEL_PDF_NPM_BINARY'),
+    'include_path' => env('LARAVEL_PDF_INCLUDE_PATH'),
+    'chrome_path' => env('LARAVEL_PDF_CHROME_PATH'),
+    'node_modules_path' => env('LARAVEL_PDF_NODE_MODULES_PATH'),
+    'bin_path' => env('LARAVEL_PDF_BIN_PATH'),
+    'temp_path' => env('LARAVEL_PDF_TEMP_PATH'),
+    'write_options_to_file' => env('LARAVEL_PDF_WRITE_OPTIONS_TO_FILE', false),
+],
+```
+
+
+## Environment Variables
+
+You can also use environment variables to configure PDF generation:
+
+```env
+LARAVEL_PDF_NODE_BINARY=/usr/local/bin/node
+LARAVEL_PDF_NPM_BINARY=/usr/local/bin/npm
+LARAVEL_PDF_INCLUDE_PATH=/usr/local/bin
+LARAVEL_PDF_CHROME_PATH=/usr/bin/google-chrome-stable
+LARAVEL_PDF_NODE_MODULES_PATH=/path/to/node_modules
+LARAVEL_PDF_BIN_PATH=/usr/local/bin
+LARAVEL_PDF_TEMP_PATH=/tmp
+LARAVEL_PDF_WRITE_OPTIONS_TO_FILE=true
+```
+
+## Overriding Configuration
+
+Configuration defaults can still be overridden on a per-PDF basis using the `withBrowsershot()` method:
+
+```php
+use Spatie\LaravelPdf\Facades\Pdf;
+use Spatie\Browsershot\Browsershot;
+
+// This PDF will use the configuration defaults plus the scale override
+Pdf::view('invoice', ['invoice' => $invoice])
+    ->withBrowsershot(function (Browsershot $browsershot) {
+        $browsershot->scale(0.8);
+    })
+    ->save('invoice.pdf');
+```
+
+The `withBrowsershot()` closure runs after configuration defaults are applied, allowing you to modify or override any setting.

--- a/docs/advanced-usage/customizing-browsershot.md
+++ b/docs/advanced-usage/customizing-browsershot.md
@@ -5,13 +5,19 @@ weight: 2
 
 Under the hood, Laravel PDF uses [Browsershot](https://spatie.be/docs/browsershot) to generate the PDFs. While Laravel PDF provides a simple interface to generate PDFs, you can still use Browsershot directly to customize the PDFs.
 
+## Configuration-Based Customization
 
-You can customize the Browsershot instance by calling the `withBrowsershot` method. This method accepts a closure that receives the Browsershot instance as its only argument. You can use this instance to customize the PDFs.
+For settings that apply to all PDFs in your application, use the [configuration file](/docs/advanced-usage/configuration) to set defaults. This is especially useful for binary paths, Chrome arguments, and language settings.
 
-Here's an example of how you can call Browsershot's `scale` method.
+## Per-PDF Customization
+
+You can customize the Browsershot instance for individual PDFs by calling the `withBrowsershot` method. This method accepts a closure that receives the Browsershot instance as its only argument.
+
+Here's an example of how you can call Browsershot's `scale` method:
 
 ```php
 use Spatie\LaravelPdf\Facades\Pdf;
+use Spatie\Browsershot\Browsershot;
 
 Pdf::view('test')
     ->withBrowsershot(function (Browsershot $browsershot) {
@@ -19,3 +25,5 @@ Pdf::view('test')
     })
     ->save($this->targetPath);
 ```
+
+The `withBrowsershot()` closure runs after configuration defaults are applied, allowing you to override or extend the default settings on a per-PDF basis.

--- a/src/PdfBuilder.php
+++ b/src/PdfBuilder.php
@@ -376,11 +376,52 @@ class PdfBuilder implements Responsable
             $browsershot->landscape();
         }
 
+        $this->applyConfigurationDefaults($browsershot);
+
         if ($this->customizeBrowsershot) {
             ($this->customizeBrowsershot)($browsershot);
         }
 
         return $browsershot;
+    }
+
+    protected function applyConfigurationDefaults(Browsershot $browsershot): void
+    {
+        $config = config('laravel-pdf.browsershot', []);
+
+        // Apply binary paths
+        if ($nodeBinary = config('laravel-pdf.browsershot.node_binary')) {
+            $browsershot->setNodeBinary($nodeBinary);
+        }
+
+        if ($npmBinary = config('laravel-pdf.browsershot.npm_binary')) {
+            $browsershot->setNpmBinary($npmBinary);
+        }
+
+        if ($includePath = config('laravel-pdf.browsershot.include_path')) {
+            $browsershot->setIncludePath($includePath);
+        }
+
+        if ($chromePath = config('laravel-pdf.browsershot.chrome_path')) {
+            $browsershot->setChromePath($chromePath);
+        }
+
+        if ($nodeModulesPath = config('laravel-pdf.browsershot.node_modules_path')) {
+            $browsershot->setNodeModulePath($nodeModulesPath);
+        }
+
+        if ($binPath = config('laravel-pdf.browsershot.bin_path')) {
+            $browsershot->setBinPath($binPath);
+        }
+
+        if ($tempPath = config('laravel-pdf.browsershot.temp_path')) {
+            $browsershot->setCustomTempPath($tempPath);
+        }
+
+        // Apply additional options
+        if ($config['write_options_to_file'] ?? false) {
+            $browsershot->writeOptionsToFile();
+        }
     }
 
     public function toResponse($request): Response

--- a/src/PdfServiceProvider.php
+++ b/src/PdfServiceProvider.php
@@ -10,7 +10,9 @@ class PdfServiceProvider extends PackageServiceProvider
 {
     public function configurePackage(Package $package): void
     {
-        $package->name('laravel-pdf');
+        $package
+            ->name('laravel-pdf')
+            ->hasConfigFile();
     }
 
     public function bootingPackage()


### PR DESCRIPTION
This PR adds a configuration file to customize Browsershot settings used by laravel-pdf.

  What's included:

  - New config/laravel-pdf.php file with binary path configurations
  - Support for environment variables with LARAVEL_PDF_ prefix
  - Configuration gets applied before the withBrowsershot() callback
  - Updated documentation showing how to use the new config options

  This makes it easier to set up PDF generation in different environments without having
  to configure every PDF individually.