### PR TITLE
feat: add global 'no sandbox' option

### DIFF
--- a/config/laravel-pdf.php
+++ b/config/laravel-pdf.php
@@ -23,5 +23,6 @@ return [
          * Other Browsershot configuration options.
          */
         'write_options_to_file' => env('LARAVEL_PDF_WRITE_OPTIONS_TO_FILE', false),
+        'no_sandbox' => env('LARAVEL_PDF_NO_SANDBOX', false),
     ],
 ];

--- a/docs/advanced-usage/configuration.md
+++ b/docs/advanced-usage/configuration.md
@@ -33,6 +33,7 @@ Configure paths to Node.js, npm, Chrome, and other binaries:
     'bin_path' => env('LARAVEL_PDF_BIN_PATH'),
     'temp_path' => env('LARAVEL_PDF_TEMP_PATH'),
     'write_options_to_file' => env('LARAVEL_PDF_WRITE_OPTIONS_TO_FILE', false),
+    'no_sandbox' => env('LARAVEL_PDF_NO_SANDBOX', false),
 ],
 ```
 
@@ -50,6 +51,7 @@ LARAVEL_PDF_NODE_MODULES_PATH=/path/to/node_modules
 LARAVEL_PDF_BIN_PATH=/usr/local/bin
 LARAVEL_PDF_TEMP_PATH=/tmp
 LARAVEL_PDF_WRITE_OPTIONS_TO_FILE=true
+LARAVEL_PDF_NO_SANDBOX=true
 ```
 
 ## Overriding Configuration

--- a/src/PdfBuilder.php
+++ b/src/PdfBuilder.php
@@ -420,6 +420,10 @@ class PdfBuilder implements Responsable
         if (config('laravel-pdf.browsershot.write_options_to_file')) {
             $browsershot->writeOptionsToFile();
         }
+
+        if (config('laravel-pdf.browsershot.no_sandbox')) {
+            $browsershot->noSandbox();
+        }
     }
 
     public function toResponse($request): Response


### PR DESCRIPTION
Hey Spatie team! 😊

First and foremost, I want to express my gratitude for all the incredible packages you’ve created.

During my recent development work, I discovered that the `noSandbox` option could be a highly useful feature, particularly in virtualized Docker environments. I believe it would be beneficial to add a global option that allows users to modify the browsershot instance.

I look forward to your thoughts on this matter.