### PR TITLE
Add support for basic auth in the Gotenberg driver

### DIFF
--- a/config/laravel-pdf.php
+++ b/config/laravel-pdf.php
@@ -59,6 +59,8 @@ return [
      */
     'gotenberg' => [
         'url' => env('GOTENBERG_URL', 'http://localhost:3000'),
+        'username' => env('GOTENBERG_USERNAME'),
+        'password' => env('GOTENBERG_PASSWORD'),
     ],
 
     /*


### PR DESCRIPTION
This adds support for configuring basic auth in the Gotenberg driver, as outlined in the documentation.

<img width="974" height="144" alt="Screenshot 2026-02-10 at 2 11 51 PM" src="https://github.com/user-attachments/assets/3fa79582-28a7-4585-8fe6-650a96272791" />
