### PR TITLE
Make generatePdfContent public

### DIFF
--- a/src/PdfBuilder.php
+++ b/src/PdfBuilder.php
@@ -484,7 +484,7 @@ class PdfBuilder implements Responsable
         return $options;
     }
 
-    protected function generatePdfContent(): string
+    public function generatePdfContent(): string
     {
         $content = $this->getDriver()->generatePdf(
             $this->getHtml(),


### PR DESCRIPTION
## Summary

- Makes the `generatePdfContent()` method public on `PdfBuilder`, allowing users to get raw PDF content directly for use cases like mail attachments without saving to a file.

Previously the only way to get raw content was:
```php
$content = base64_decode($pdf->base64());
```

Now you can simply call:
```php
$content = $pdf->generatePdfContent();
```

Closes #315