### PR TITLE
Implement toMailAttachment and Attachable on PdfBuilder

### DIFF
--- a/docs/basic-usage/attaching-pdfs-to-mails.md
+++ b/docs/basic-usage/attaching-pdfs-to-mails.md
@@ -1,0 +1,46 @@
+---
+title: Attaching PDFs to mails
+weight: 5
+---
+
+A `PdfBuilder` instance implements Laravel's `Illuminate\Contracts\Mail\Attachable` contract. This means you can pass a PDF directly to the `attach` method of a mailable or notification, without first having to save it to disk.
+
+Here's an example of a notification that attaches a generated invoice PDF.
+
+```php
+use Illuminate\Notifications\Messages\MailMessage;
+use Spatie\LaravelPdf\Facades\Pdf;
+
+public function toMail(object $notifiable): MailMessage
+{
+    $pdf = Pdf::view('pdfs.invoice', ['invoice' => $this->invoice])
+        ->name('invoice.pdf');
+
+    return (new MailMessage)
+        ->subject('Your invoice')
+        ->line('Please find your invoice attached.')
+        ->attach($pdf);
+}
+```
+
+The filename of the attachment is taken from the PDF's `name()`. The MIME type is set to `application/pdf`.
+
+You can also use it in a mailable.
+
+```php
+use Illuminate\Mail\Mailable;
+use Spatie\LaravelPdf\Facades\Pdf;
+
+class InvoiceMail extends Mailable
+{
+    public function __construct(public Invoice $invoice) {}
+
+    public function attachments(): array
+    {
+        return [
+            Pdf::view('pdfs.invoice', ['invoice' => $this->invoice])
+                ->name('invoice.pdf'),
+        ];
+    }
+}
+```

--- a/docs/basic-usage/queued-pdf-generation.md
+++ b/docs/basic-usage/queued-pdf-generation.md
@@ -1,6 +1,6 @@
 ---
 title: Queued PDF generation
-weight: 5
+weight: 6
 ---
 
 PDF generation can be slow, especially with the Browsershot or Cloudflare driver. If you don't need the PDF immediately, you can dispatch the generation to a background queue using `saveQueued()`.

--- a/docs/basic-usage/setting-defaults.md
+++ b/docs/basic-usage/setting-defaults.md
@@ -1,6 +1,6 @@
 ---
 title: Setting defaults
-weight: 7
+weight: 8
 ---
 
 You can set the default options for every PDF, by using the `default` method on the `Pdf` facade.

--- a/docs/basic-usage/testing-pdfs.md
+++ b/docs/basic-usage/testing-pdfs.md
@@ -1,6 +1,6 @@
 ---
 title: Testing PDFs
-weight: 6
+weight: 7
 ---
 
 In your test, you can call the `fake()` method on the `Pdf` facade to fake the PDF generation. Because the PDF generation is faked, your tests will run much faster.

--- a/src/PdfBuilder.php
+++ b/src/PdfBuilder.php
@@ -4,9 +4,11 @@ namespace Spatie\LaravelPdf;
 
 use Closure;
 use DateTimeInterface;
+use Illuminate\Contracts\Mail\Attachable;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Foundation\Bus\PendingDispatch;
 use Illuminate\Http\Response;
+use Illuminate\Mail\Attachment;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Dumpable;
@@ -19,7 +21,7 @@ use Spatie\LaravelPdf\Exceptions\CouldNotGeneratePdf;
 use Spatie\LaravelPdf\Jobs\GeneratePdfJob;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
 
-class PdfBuilder implements Responsable
+class PdfBuilder implements Attachable, Responsable
 {
     use Conditionable;
     use Dumpable;
@@ -529,6 +531,13 @@ class PdfBuilder implements Responsable
         $pdfContent = $this->generatePdfContent();
 
         return response($pdfContent, 200, $this->responseHeaders);
+    }
+
+    public function toMailAttachment(): Attachment
+    {
+        return Attachment::fromData(fn () => $this->generatePdfContent())
+            ->as($this->downloadName)
+            ->withMime('application/pdf');
     }
 
     protected function addHeaders(array $headers): self

--- a/tests/Integration/PdfMailAttachmentTest.php
+++ b/tests/Integration/PdfMailAttachmentTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Contracts\Mail\Attachable;
+use Illuminate\Mail\Attachment;
+use Spatie\LaravelPdf\Facades\Pdf;
+use Spatie\LaravelPdf\PdfBuilder;
+
+it('implements the Attachable contract', function () {
+    expect(Pdf::view('test'))->toBeInstanceOf(Attachable::class);
+});
+
+it('can be converted to a mail attachment', function () {
+    $attachment = Pdf::view('test')
+        ->name('invoice.pdf')
+        ->toMailAttachment();
+
+    expect($attachment)
+        ->toBeInstanceOf(Attachment::class)
+        ->and($attachment->as)->toBe('invoice.pdf')
+        ->and($attachment->mime)->toBe('application/pdf');
+});
+
+it('adds the pdf extension to the mail attachment filename when missing', function () {
+    $attachment = Pdf::view('test')
+        ->name('invoice')
+        ->toMailAttachment();
+
+    expect($attachment->as)->toBe('invoice.pdf');
+});
+
+it('generates pdf content when the attachment is resolved', function () {
+    $pdfContent = null;
+
+    Pdf::view('test')
+        ->name('invoice.pdf')
+        ->toMailAttachment()
+        ->attachWith(
+            fn () => null,
+            function (Closure $data) use (&$pdfContent) {
+                $pdfContent = $data();
+            },
+        );
+
+    expect($pdfContent)
+        ->toBeString()
+        ->toStartWith('%PDF-');
+});
+
+it('can be used as a mail attachment on a PdfBuilder instance', function () {
+    $builder = Pdf::view('test')->name('invoice.pdf');
+
+    expect($builder)->toBeInstanceOf(PdfBuilder::class);
+
+    $attachment = $builder->toMailAttachment();
+
+    expect($attachment->as)->toBe('invoice.pdf');
+});


### PR DESCRIPTION
### Summary

This PR makes `Spatie\LaravelPdf\PdfBuilder` implement Laravel’s `Illuminate\Contracts\Mail\Attachable` contract and adds a `toMailAttachment()` method. This allows any `PdfBuilder` instance to be used directly as a mail attachment in Laravel’s mailable classes.

### Usage Example

It can be used in notifications like this:

```php
use Illuminate\Notifications\Messages\MailMessage;
use Spatie\LaravelPdf\Facades\Pdf;

public function toMail(object $notifiable): MailMessage
{
    $pdf = Pdf::view('pdfs.invoice', [
        'invoice' => $invoice,
    ]);

    return (new MailMessage)
        ->subject('Your invoice')
        ->line('Please find your invoice attached.')
        ->attach($pdf);
}
```