### PR TITLE
Implemented an option to add watermarks

### DIFF
--- a/src/PdfBuilder.php
+++ b/src/PdfBuilder.php
@@ -137,6 +137,17 @@ class PdfBuilder implements Attachable, Responsable
         return $this;
     }
 
+    public function setWatermark(?string $viewName = null, ?array $viewData = []): self
+    {
+        if ($viewName !== null) {
+            $this->headerHtml = $this->getHeaderHtml() . view($viewName, $viewData)->render();
+            $this->headerViewName = '';
+            $this->headerData = [];
+        }
+
+        return $this;
+    }
+
     public function landscape(): self
     {
         return $this->orientation(Orientation::Landscape);


### PR DESCRIPTION
This pull request enables the option to add watermarks on each page by extending the header html.

Example usage:

```php
/**
* both params viewName and viewData are optional,
*  the watermark is only applied if there is a view. 
* In that way the user can use ternary statements to conditionaly set the view
*/

 Pdf::view(...)
->setWatermark(viewName: 'confidential', viewData: null) 
->generatePdfContent();
```

```blade
<!-- confidential.blade.php -->
<div>
    <style>
        .watermark {
            position: absolute;
            width: 100%;
            top: 50%;
            left: 50%;
            text-align: center;
            opacity: 0.3;
            font-size: 80px;
            color: red;
            transform: translateX(-50%) translateY(-50%) rotate(-45deg);
            transform-origin: center;
            pointer-events: none;
        }
    </style>
    <div class="watermark">
        Confidential
    </div>
</div>
```