### PR TITLE
feat(chrome): implement chrome-php/chrome driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
     
 </div>
 
-This package provides a simple way to create PDFs in Laravel apps. It supports multiple drivers: [Browsershot](https://spatie.be/docs/browsershot) (Chromium), [Gotenberg](https://gotenberg.dev) (Docker-based), [Cloudflare Browser Rendering](https://developers.cloudflare.com/browser-rendering/), [WeasyPrint](https://doc.courtbouillon.org/weasyprint/stable/) (Python-based), and [DOMPDF](https://github.com/dompdf/dompdf) (pure PHP). You can use modern CSS features like grid and flexbox with the Chromium-based drivers, use WeasyPrint for excellent CSS Paged Media support, or choose DOMPDF for a zero-dependency setup.
+This package provides a simple way to create PDFs in Laravel apps. It supports multiple drivers: [Browsershot](https://spatie.be/docs/browsershot) (Chromium), [Gotenberg](https://gotenberg.dev) (Docker-based), [Cloudflare Browser Rendering](https://developers.cloudflare.com/browser-rendering/), [WeasyPrint](https://doc.courtbouillon.org/weasyprint/stable/) (Python-based), [DOMPDF](https://github.com/dompdf/dompdf) (pure PHP), and [chrome-php/chrome](https://github.com/chrome-php/chrome) (Chromium). You can use modern CSS features like grid and flexbox with the Chromium-based drivers, use WeasyPrint for excellent CSS Paged Media support, or choose DOMPDF for a zero-dependency setup.
 
 Here's a quick example:
 

--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,13 @@
         "spatie/temporary-directory": "^2.2.1"
     },
     "suggest": {
+        "chrome-php/chrome": "Required for the Chrome PHP driver (^1.0)",
         "dompdf/dompdf": "Required for the DOMPDF driver (^3.0)",
         "spatie/browsershot": "Required for the Browsershot driver (^4.0|^5.0)"
     },
     "require-dev": {
         "ext-imagick": "*",
+        "chrome-php/chrome": "^1.0",
         "dompdf/dompdf": "^3.0",
         "larastan/larastan": "^2.7.0|^3.0",
         "laravel/pint": "^1.13.7",

--- a/config/laravel-pdf.php
+++ b/config/laravel-pdf.php
@@ -5,7 +5,7 @@ use Spatie\LaravelPdf\Jobs\GeneratePdfJob;
 return [
     /*
      * The default driver to use for PDF generation.
-     * Supported: "browsershot", "cloudflare", "dompdf", "gotenberg"
+     * Supported: "browsershot", "cloudflare", "dompdf", "gotenberg", "chrome"
      */
     'driver' => env('LARAVEL_PDF_DRIVER', 'browsershot'),
 
@@ -104,5 +104,29 @@ return [
          * The timeout (default = 10 seconds)
          */
         'timeout' => 10,
+    ],
+
+    /*
+     * Chrome PHP driver configuration.
+     *
+     * Requires the Chrome/Chromium executable and chrome-php/chrome package:
+     * composer require chrome-php/chrome
+     *
+     * @see https://github.com/chrome-php/chrome
+     */
+    'chrome' => [
+        'chrome_binary' => env('LARAVEL_PDF_CHROME_BINARY'),
+
+        'no_sandbox' => env('LARAVEL_PDF_CHROME_NO_SANDBOX', false),
+
+        'startup_timeout' => env('LARAVEL_PDF_CHROME_STARTUP_TIMEOUT', 30),
+
+        'timeout' => env('LARAVEL_PDF_CHROME_TIMEOUT', 30000),
+
+        'user_data_dir' => env('LARAVEL_PDF_CHROME_USER_DATA_DIR'),
+
+        'custom_flags' => [],
+
+        'env_variables' => [],
     ],
 ];

--- a/docs/advanced-usage/creating-pdfs-with-multiple-pages.md
+++ b/docs/advanced-usage/creating-pdfs-with-multiple-pages.md
@@ -51,4 +51,4 @@ Pdf::view('view-with-multiple-pages')->footerView('footer-view')->save($path);
 
 ... the resulting PDF will have a footer on each page, with the page number and the total number of pages.
 
-> **Note:** `@pageNumber` and `@totalPages` only work with the Browsershot and Cloudflare drivers. The DOMPDF driver does not support these directives.
+> **Note:** `@pageNumber` and `@totalPages` only work with the Browsershot, Cloudflare and Chrome drivers. The DOMPDF driver does not support these directives.

--- a/docs/basic-usage/creating-pdfs.md
+++ b/docs/basic-usage/creating-pdfs.md
@@ -32,7 +32,7 @@ Pdf::html('<h1>Hello world!!</h1>')->save('/some/directory/invoice.pdf');
 
 ## Using JavaScript
 
-When using a browser-based driver (Browsershot or Cloudflare), the JavaScript in your HTML will be executed when the PDF is created. You could use this to have a JavaScript charting library render a chart. The DomPDF driver does not support JavaScript execution.
+When using a browser-based driver (Browsershot, Cloudflare or Chrome), the JavaScript in your HTML will be executed when the PDF is created. You could use this to have a JavaScript charting library render a chart. The DomPDF driver does not support JavaScript execution.
 
 Here's a simple example. If you have this Blade view...
 

--- a/docs/basic-usage/formatting-pdfs.md
+++ b/docs/basic-usage/formatting-pdfs.md
@@ -48,7 +48,7 @@ Inside the footer, you can use the following Blade directives:
 - `@pageNumber`:  The current page number
 - `@totalPages`:  The total number of pages
 
-> `@pageNumber` and `@totalPages` only work with the Browsershot and Cloudflare drivers. The DOMPDF driver does not support these directives.
+> `@pageNumber` and `@totalPages` only work with the Browsershot, Cloudflare and Chrome drivers. The DOMPDF driver does not support these directives.
 
 ### Display Images in Headers and Footers
 
@@ -165,7 +165,7 @@ Pdf::view('pdf.invoice', ['invoice' => $invoice])
     ->save('/some/directory/invoice.pdf');
 ```
 
-> Scale is supported by the Browsershot and Cloudflare drivers. The DOMPDF driver does not support this option.
+> Scale is supported by the Browsershot, Cloudflare and Chrome drivers. The DOMPDF driver does not support this option.
 
 ## Page ranges
 
@@ -179,7 +179,7 @@ Pdf::view('pdf.report', ['report' => $report])
     ->save('/some/directory/report.pdf');
 ```
 
-> Page ranges are supported by the Browsershot and Cloudflare drivers. The DOMPDF driver does not support this option.
+> Page ranges are supported by the Browsershot, Cloudflare and Chrome drivers. The DOMPDF driver does not support this option.
 
 ## Tagged PDF
 

--- a/docs/basic-usage/queued-pdf-generation.md
+++ b/docs/basic-usage/queued-pdf-generation.md
@@ -3,7 +3,7 @@ title: Queued PDF generation
 weight: 6
 ---
 
-PDF generation can be slow, especially with the Browsershot or Cloudflare driver. If you don't need the PDF immediately, you can dispatch the generation to a background queue using `saveQueued()`.
+PDF generation can be slow, especially with the Browsershot, Cloudflare and Chrome drivers. If you don't need the PDF immediately, you can dispatch the generation to a background queue using `saveQueued()`.
 
 ## Basic usage
 

--- a/docs/drivers/configuration.md
+++ b/docs/drivers/configuration.md
@@ -23,7 +23,7 @@ The `driver` option determines which PDF generation backend to use:
 'driver' => env('LARAVEL_PDF_DRIVER', 'browsershot'),
 ```
 
-Supported values: `browsershot`, `cloudflare`, `dompdf`, `gotenberg`, `weasyprint`.
+Supported values: `browsershot`, `chrome`, `cloudflare`, `dompdf`, `gotenberg`, `weasyprint`.
 
 ## Browsershot Configuration
 
@@ -53,6 +53,30 @@ Configure the Cloudflare Browser Rendering API credentials:
     'account_id' => env('CLOUDFLARE_ACCOUNT_ID'),
 ],
 ```
+
+## Chrome Configuration
+
+Configure the Chrome driver options:
+
+```php
+'chrome' => [
+    'chrome_binary' => env('LARAVEL_PDF_CHROME_BINARY', env('LARAVEL_PDF_CHROME_PATH')),
+    'no_sandbox' => env('LARAVEL_PDF_CHROME_NO_SANDBOX', false),
+    'startup_timeout' => env('LARAVEL_PDF_CHROME_STARTUP_TIMEOUT', 30),
+    'timeout' => env('LARAVEL_PDF_CHROME_TIMEOUT', 30000),
+    'user_data_dir' => env('LARAVEL_PDF_CHROME_USER_DATA_DIR'),
+    'custom_flags' => [],
+    'env_variables' => [],
+],
+```
+
+- **chrome_binary**: Path to the Chrome or Chromium executable. Defaults to auto-discovery when available.
+- **no_sandbox**: Disables Chrome's sandbox. This is sometimes needed in Docker or restricted server environments.
+- **startup_timeout**: Maximum time in seconds to wait for Chrome to start.
+- **timeout**: Maximum time in milliseconds to wait while setting the page HTML.
+- **user_data_dir**: Custom Chrome profile directory.
+- **custom_flags**: Additional Chrome command-line flags.
+- **env_variables**: Environment variables passed to the Chrome process.
 
 ## Gotenberg Configuration
 
@@ -114,6 +138,13 @@ LARAVEL_PDF_NO_SANDBOX=true
 # Cloudflare settings
 CLOUDFLARE_API_TOKEN=your-api-token
 CLOUDFLARE_ACCOUNT_ID=your-account-id
+
+# Chrome driver settings
+LARAVEL_PDF_CHROME_BINARY=/usr/bin/google-chrome-stable
+LARAVEL_PDF_CHROME_NO_SANDBOX=false
+LARAVEL_PDF_CHROME_STARTUP_TIMEOUT=30
+LARAVEL_PDF_CHROME_TIMEOUT=30000
+LARAVEL_PDF_CHROME_USER_DATA_DIR=/tmp/chrome-profile
 
 # Gotenberg settings
 GOTENBERG_URL=http://localhost:3000

--- a/docs/drivers/configuration.md
+++ b/docs/drivers/configuration.md
@@ -60,7 +60,7 @@ Configure the Chrome driver options:
 
 ```php
 'chrome' => [
-    'chrome_binary' => env('LARAVEL_PDF_CHROME_BINARY', env('LARAVEL_PDF_CHROME_PATH')),
+    'chrome_binary' => env('LARAVEL_PDF_CHROME_BINARY'),
     'no_sandbox' => env('LARAVEL_PDF_CHROME_NO_SANDBOX', false),
     'startup_timeout' => env('LARAVEL_PDF_CHROME_STARTUP_TIMEOUT', 30),
     'timeout' => env('LARAVEL_PDF_CHROME_TIMEOUT', 30000),

--- a/docs/drivers/using-the-chrome-driver.md
+++ b/docs/drivers/using-the-chrome-driver.md
@@ -58,7 +58,7 @@ The Chrome driver accepts these configuration options in `config/laravel-pdf.php
 
 ```php
 'chrome' => [
-    'chrome_binary' => env('LARAVEL_PDF_CHROME_BINARY', env('LARAVEL_PDF_CHROME_PATH')),
+    'chrome_binary' => env('LARAVEL_PDF_CHROME_BINARY'),
     'no_sandbox' => env('LARAVEL_PDF_CHROME_NO_SANDBOX', false),
     'startup_timeout' => env('LARAVEL_PDF_CHROME_STARTUP_TIMEOUT', 30),
     'timeout' => env('LARAVEL_PDF_CHROME_TIMEOUT', 30000),

--- a/docs/drivers/using-the-chrome-driver.md
+++ b/docs/drivers/using-the-chrome-driver.md
@@ -1,0 +1,97 @@
+---
+title: Using the Chrome driver
+weight: 5
+---
+
+The Chrome driver uses [chrome-php/chrome](https://github.com/chrome-php/chrome) to generate PDFs directly from PHP. It is a good fit when you want a Chromium-based driver without bringing in Node.js or Puppeteer.
+
+## Getting started
+
+1. Install the Chrome package:
+
+```bash
+composer require chrome-php/chrome
+```
+
+2. Make sure Chrome or Chromium is installed on the machine that generates the PDFs.
+
+The upstream library requires a Chrome/Chromium 65+ executable. It can auto-discover the browser in common locations, but you can also configure the binary path explicitly.
+
+3. Set the driver in your `.env` file:
+
+```env
+LARAVEL_PDF_DRIVER=chrome
+```
+
+If Chrome cannot be auto-discovered, also set the browser path:
+
+```env
+LARAVEL_PDF_CHROME_BINARY=/usr/bin/google-chrome-stable
+```
+
+That's it. Your existing PDF code will now use the Chrome driver:
+
+```php
+use Spatie\LaravelPdf\Facades\Pdf;
+
+Pdf::view('pdfs.invoice', ['invoice' => $invoice])
+    ->format('a4')
+    ->save('invoice.pdf');
+```
+
+## Supported options
+
+The Chrome driver supports the following PDF options:
+
+- `format()` — Paper format (a4, letter, legal, etc.)
+- `paperSize()` — Custom paper dimensions
+- `margins()` — Page margins
+- `landscape()` / `orientation()` — Page orientation
+- `scale()` — Page rendering scale
+- `pageRanges()` — Specific pages to include
+- `headerView()` / `headerHtml()` — Page headers
+- `footerView()` / `footerHtml()` — Page footers
+
+## Configuration
+
+The Chrome driver accepts these configuration options in `config/laravel-pdf.php`:
+
+```php
+'chrome' => [
+    'chrome_binary' => env('LARAVEL_PDF_CHROME_BINARY', env('LARAVEL_PDF_CHROME_PATH')),
+    'no_sandbox' => env('LARAVEL_PDF_CHROME_NO_SANDBOX', false),
+    'startup_timeout' => env('LARAVEL_PDF_CHROME_STARTUP_TIMEOUT', 30),
+    'timeout' => env('LARAVEL_PDF_CHROME_TIMEOUT', 30000),
+    'user_data_dir' => env('LARAVEL_PDF_CHROME_USER_DATA_DIR'),
+    'custom_flags' => [],
+    'env_variables' => [],
+],
+```
+
+- **chrome_binary**: The path to the Chrome or Chromium executable. If omitted, the driver will try to auto-discover it.
+- **no_sandbox**: Disables Chrome's sandbox. This is sometimes needed in Docker or restricted server environments.
+- **startup_timeout**: Maximum time in seconds to wait for Chrome to start.
+- **timeout**: Maximum time in milliseconds to wait when setting the page HTML.
+- **user_data_dir**: Custom Chrome profile directory.
+- **custom_flags**: Additional Chrome command-line flags.
+- **env_variables**: Environment variables passed to the Chrome process.
+
+## Using Chrome for specific PDFs only
+
+If you want to use another driver as your default but switch to Chrome for specific PDFs, use the `driver` method:
+
+```php
+use Spatie\LaravelPdf\Facades\Pdf;
+
+Pdf::view('pdfs.invoice', ['invoice' => $invoice])
+    ->driver('chrome')
+    ->format('a4')
+    ->save('invoice.pdf');
+```
+
+## Limitations
+
+- The Chrome driver requires both the `chrome-php/chrome` package and a local Chrome or Chromium executable. It does not download or bundle a browser for you.
+- In Docker or other locked-down environments, you may need to enable `no_sandbox`.
+- This driver only documents and exposes the options supported by Laravel PDF. If you need deeper Chromium customization, use the Browsershot driver instead.
+- The `tagged()`, `withBrowsershot()` and `onLambda()` methods have no effect when using the Chrome driver.

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -159,7 +159,7 @@ return [
     ],
 
     'chrome' => [
-        'chrome_binary' => env('LARAVEL_PDF_CHROME_BINARY', env('LARAVEL_PDF_CHROME_PATH')),
+        'chrome_binary' => env('LARAVEL_PDF_CHROME_BINARY'),
         'no_sandbox' => env('LARAVEL_PDF_CHROME_NO_SANDBOX', false),
         'startup_timeout' => env('LARAVEL_PDF_CHROME_STARTUP_TIMEOUT', 30),
         'timeout' => env('LARAVEL_PDF_CHROME_TIMEOUT', 30000),

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -95,6 +95,24 @@ LARAVEL_PDF_DRIVER=dompdf
 
 Note that DOMPDF has more limited CSS support than the Chromium-based drivers. See [Using the DOMPDF driver](/docs/laravel-pdf/v2/drivers/using-the-dompdf-driver) for details.
 
+### Chrome driver
+
+The Chrome driver uses [chrome-php/chrome](https://github.com/chrome-php/chrome) to talk directly to a local Chrome or Chromium binary from PHP.
+
+```bash
+composer require chrome-php/chrome
+```
+
+Then set the driver in your `.env` file:
+
+```env
+LARAVEL_PDF_DRIVER=chrome
+```
+
+You'll also need to install the Chrome/Chromium binary to work. You can find the instructions [here](https://www.chromium.org/getting-involved/download-chromium/).
+
+See [Using the Chrome driver](/docs/laravel-pdf/v2/drivers/using-the-chrome-driver) for more details on configuration, supported options, and limitations.
+
 ## Laravel Boost
 
 This package ships with a [Laravel Boost](https://laravel.com/docs/12.x/boost) skill. After installing the package, run `php artisan boost:install` to register the skill. This will help AI agents in your project generate correct PDF code.
@@ -140,5 +158,14 @@ return [
         'timeout' => 10,
     ],
 
+    'chrome' => [
+        'chrome_binary' => env('LARAVEL_PDF_CHROME_BINARY', env('LARAVEL_PDF_CHROME_PATH')),
+        'no_sandbox' => env('LARAVEL_PDF_CHROME_NO_SANDBOX', false),
+        'startup_timeout' => env('LARAVEL_PDF_CHROME_STARTUP_TIMEOUT', 30),
+        'timeout' => env('LARAVEL_PDF_CHROME_TIMEOUT', 30000),
+        'user_data_dir' => env('LARAVEL_PDF_CHROME_USER_DATA_DIR'),
+        'custom_flags' => [],
+        'env_variables' => [],
+    ],
 ];
 ```

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -10,8 +10,9 @@ This package provides a simple way to create PDFs in Laravel apps. It uses a dri
 - **Cloudflare**: Uses [Cloudflare's Browser Rendering API](https://developers.cloudflare.com/browser-rendering/) to generate PDFs with a simple HTTP call. No Node.js or Chrome binary needed. This driver was inspired by [a suggestion from Dries Vints](https://x.com/driesvints/status/2016131972477632850).
 - **WeasyPrint**: Uses [WeasyPrint](https://doc.courtbouillon.org/weasyprint/stable/) via [pontedilana/php-weasyprint](https://github.com/pontedilana/php-weasyprint) for Python-based PDF generation with excellent CSS Paged Media support. Requires the WeasyPrint binary.
 - **DOMPDF**: Uses [dompdf/dompdf](https://github.com/dompdf/dompdf) for pure PHP PDF generation. No external binaries, no Node.js, no Docker — works everywhere PHP runs.
+- **Chrome**: Uses [chrome-php/chrome](https://github.com/chrome-php/chrome) to talk directly to a local Chrome or Chromium binary from PHP. Requires a Chrome/Chromium 65+ executable.
 
-The Browsershot, Gotenberg, and Cloudflare drivers support modern CSS features like grid and flexbox, or even a framework like Tailwind, to create beautiful PDFs. The WeasyPrint driver supports CSS Paged Media, making it a strong choice for documents with repeating headers/footers and page counters. The DOMPDF driver supports CSS 2.1 and some CSS 3 properties, making it ideal for simpler PDFs that don't need advanced layout features.
+The Browsershot, Gotenberg, Cloudflare, and Chrome drivers support modern CSS features like grid and flexbox, or even a framework like Tailwind, to create beautiful PDFs. The WeasyPrint driver supports CSS Paged Media, making it a strong choice for documents with repeating headers/footers and page counters. The DOMPDF driver supports CSS 2.1 and some CSS 3 properties, making it ideal for simpler PDFs that don't need advanced layout features.
 
 Here's a quick example:
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -39,3 +39,10 @@ The Cloudflare driver uses [Cloudflare's Browser Rendering API](https://develope
 - A [Cloudflare account](https://dash.cloudflare.com/sign-up) with the Browser Rendering API enabled
 - A Cloudflare API token with the appropriate permissions
 - Your Cloudflare account ID
+
+## Chrome driver
+
+The Chrome driver uses [chrome-php/chrome](https://github.com/chrome-php/chrome) to talk directly to a local Chrome or Chromium binary from PHP. You will need:
+
+- The PHP wrapper package: `composer require chrome-php/chrome`
+- A Chrome/Chromium 65+ executable.

--- a/resources/boost/skills/laravel-pdf/SKILL.md
+++ b/resources/boost/skills/laravel-pdf/SKILL.md
@@ -217,7 +217,7 @@ composer require chrome-php/chrome
 LARAVEL_PDF_DRIVER=chrome
 ```
 
-The Cloudflare driver does not support `tagged`, `withBrowsershot()`, `onLambda()`, or PNG output.
+The Chrome driver does not support `tagged`, `withBrowsershot()`, `onLambda()`, or PNG output.
 
 ## Queued PDF generation
 

--- a/resources/boost/skills/laravel-pdf/SKILL.md
+++ b/resources/boost/skills/laravel-pdf/SKILL.md
@@ -205,6 +205,20 @@ Pdf::view('pdf.invoice', $data)
     ->save('invoice.pdf');
 ```
 
+### Chrome driver
+
+Requires `chrome-php/chrome` and a local Chrome/Chromium binary.
+
+```bash
+composer require chrome-php/chrome
+```
+
+```env
+LARAVEL_PDF_DRIVER=chrome
+```
+
+The Cloudflare driver does not support `tagged`, `withBrowsershot()`, `onLambda()`, or PNG output.
+
 ## Queued PDF generation
 
 Dispatch PDF generation to a background queue:

--- a/src/Drivers/ChromeDriver.php
+++ b/src/Drivers/ChromeDriver.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Spatie\LaravelPdf\Drivers;
+
+use HeadlessChromium\Browser\ProcessAwareBrowser;
+use HeadlessChromium\BrowserFactory;
+use Spatie\LaravelPdf\Enums\Orientation;
+use Spatie\LaravelPdf\Exceptions\CouldNotGeneratePdf;
+use Spatie\LaravelPdf\PdfOptions;
+
+class ChromeDriver implements PdfDriver
+{
+    protected array $config;
+
+    /**
+     * Paper sizes in inches [width, height].
+     */
+    protected const PAPER_SIZES = [
+        'letter' => [8.5, 11],
+        'legal' => [8.5, 14],
+        'tabloid' => [11, 17],
+        'ledger' => [17, 11],
+        'a0' => [33.1, 46.8],
+        'a1' => [23.4, 33.1],
+        'a2' => [16.54, 23.4],
+        'a3' => [11.7, 16.54],
+        'a4' => [8.27, 11.7],
+        'a5' => [5.83, 8.27],
+        'a6' => [4.13, 5.83],
+    ];
+
+    /**
+     * Conversion factors to inches.
+     */
+    protected const UNIT_TO_INCHES = [
+        'mm' => 0.0393701,
+        'cm' => 0.393701,
+        'in' => 1.0,
+        'px' => 0.0104167,
+    ];
+
+    public function __construct(array $config = [])
+    {
+        if (! class_exists(BrowserFactory::class)) {
+            throw CouldNotGeneratePdf::chromeNotInstalled();
+        }
+
+        $this->config = $config;
+    }
+
+    public function generatePdf(string $html, ?string $headerHtml, ?string $footerHtml, PdfOptions $options): string
+    {
+        $browser = $this->createBrowser();
+
+        try {
+            $page = $browser->createPage();
+            $page->setHtml($html, $this->config['timeout'] ?? 30000);
+
+            $pdfOptions = $this->buildPdfOptions($headerHtml, $footerHtml, $options);
+            $pdf = $page->pdf($pdfOptions);
+
+            return $pdf->getRawBinary();
+        } finally {
+            $browser->close();
+        }
+    }
+
+    public function savePdf(string $html, ?string $headerHtml, ?string $footerHtml, PdfOptions $options, string $path): void
+    {
+        $browser = $this->createBrowser();
+
+        try {
+            $page = $browser->createPage();
+            $page->setHtml($html, $this->config['timeout'] ?? 30000);
+
+            $pdfOptions = $this->buildPdfOptions($headerHtml, $footerHtml, $options);
+            $page->pdf($pdfOptions)->saveToFile($path);
+        } finally {
+            $browser->close();
+        }
+    }
+
+    protected function createBrowser(): ProcessAwareBrowser
+    {
+        return (new BrowserFactory($this->config['chrome_binary'] ?? null))
+            ->createBrowser($this->buildBrowserOptions());
+    }
+
+    protected function buildBrowserOptions(): array
+    {
+        $options = [
+            'headless' => true,
+        ];
+
+        if ($this->config['no_sandbox'] ?? false) {
+            $options['noSandbox'] = true;
+        }
+
+        if ($startupTimeout = ($this->config['startup_timeout'] ?? null)) {
+            $options['startupTimeout'] = $startupTimeout;
+        }
+
+        if ($userDataDir = ($this->config['user_data_dir'] ?? null)) {
+            $options['userDataDir'] = $userDataDir;
+        }
+
+        if ($customFlags = ($this->config['custom_flags'] ?? null)) {
+            $options['customFlags'] = $customFlags;
+        }
+
+        if ($envVariables = ($this->config['env_variables'] ?? null)) {
+            $options['envVariables'] = $envVariables;
+        }
+
+        return $options;
+    }
+
+    protected function buildPdfOptions(?string $headerHtml, ?string $footerHtml, PdfOptions $options): array
+    {
+        $pdfOptions = [
+            'printBackground' => true,
+        ];
+
+        if ($options->format) {
+            $format = strtolower($options->format);
+
+            if (isset(self::PAPER_SIZES[$format])) {
+                [$width, $height] = self::PAPER_SIZES[$format];
+                $pdfOptions['paperWidth'] = $width;
+                $pdfOptions['paperHeight'] = $height;
+            }
+        }
+
+        if ($options->paperSize) {
+            $unit = $options->paperSize['unit'] ?? 'mm';
+            $factor = self::UNIT_TO_INCHES[$unit] ?? self::UNIT_TO_INCHES['mm'];
+
+            $pdfOptions['paperWidth'] = $options->paperSize['width'] * $factor;
+            $pdfOptions['paperHeight'] = $options->paperSize['height'] * $factor;
+        }
+
+        if ($options->margins) {
+            $unit = $options->margins['unit'] ?? 'mm';
+            $factor = self::UNIT_TO_INCHES[$unit] ?? self::UNIT_TO_INCHES['mm'];
+
+            $pdfOptions['marginTop'] = $options->margins['top'] * $factor;
+            $pdfOptions['marginRight'] = $options->margins['right'] * $factor;
+            $pdfOptions['marginBottom'] = $options->margins['bottom'] * $factor;
+            $pdfOptions['marginLeft'] = $options->margins['left'] * $factor;
+        }
+
+        if ($options->orientation === Orientation::Landscape->value) {
+            $pdfOptions['landscape'] = true;
+        }
+
+        if ($options->scale !== null) {
+            $pdfOptions['scale'] = $options->scale;
+        }
+
+        if ($options->pageRanges !== null) {
+            $pdfOptions['pageRanges'] = $options->pageRanges;
+        }
+
+        if ($headerHtml || $footerHtml) {
+            $pdfOptions['displayHeaderFooter'] = true;
+
+            if ($headerHtml) {
+                $pdfOptions['headerTemplate'] = $headerHtml;
+            }
+
+            if ($footerHtml) {
+                $pdfOptions['footerTemplate'] = $footerHtml;
+            }
+        }
+
+        return $pdfOptions;
+    }
+}

--- a/src/Exceptions/CouldNotGeneratePdf.php
+++ b/src/Exceptions/CouldNotGeneratePdf.php
@@ -48,6 +48,14 @@ class CouldNotGeneratePdf extends Exception
         return new self("Gotenberg PDF generation failed: {$body}");
     }
 
+    public static function chromeNotInstalled(): self
+    {
+        return new self(
+            'The chrome-php/chrome package is required to use the Chrome PHP driver. '
+            .'Install it with: composer require chrome-php/chrome'
+        );
+    }
+
     public static function cannotQueueWithBrowsershotClosure(): self
     {
         return new self(

--- a/src/PdfServiceProvider.php
+++ b/src/PdfServiceProvider.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Blade;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Spatie\LaravelPdf\Drivers\BrowsershotDriver;
+use Spatie\LaravelPdf\Drivers\ChromeDriver;
 use Spatie\LaravelPdf\Drivers\CloudflareDriver;
 use Spatie\LaravelPdf\Drivers\DomPdfDriver;
 use Spatie\LaravelPdf\Drivers\GotenbergDriver;
@@ -44,6 +45,10 @@ class PdfServiceProvider extends PackageServiceProvider
             return new GotenbergDriver(config('laravel-pdf.gotenberg', []));
         });
 
+        $this->app->singleton('laravel-pdf.driver.chrome', function () {
+            return new ChromeDriver(config('laravel-pdf.chrome', []));
+        });
+
         $this->app->singleton(PdfDriver::class, function () {
             $driverName = config('laravel-pdf.driver', 'browsershot');
 
@@ -53,6 +58,7 @@ class PdfServiceProvider extends PackageServiceProvider
                 'dompdf' => app('laravel-pdf.driver.dompdf'),
                 'gotenberg' => app('laravel-pdf.driver.gotenberg'),
                 'weasyprint' => app('laravel-pdf.driver.weasyprint'),
+                'chrome' => app('laravel-pdf.driver.chrome'),
                 default => throw InvalidDriver::unknown($driverName),
             };
         });

--- a/tests/Integration/ChromeIntegrationTest.php
+++ b/tests/Integration/ChromeIntegrationTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use Spatie\LaravelPdf\Drivers\ChromeDriver;
+use Spatie\LaravelPdf\PdfOptions;
+
+beforeEach(function () {
+    $this->driver = new ChromeDriver;
+});
+
+it('generates a pdf with default options', function () {
+    $result = $this->driver->generatePdf('<h1>Hello</h1>', null, null, new PdfOptions);
+
+    expect($result)->toStartWith('%PDF');
+});
+
+it('saves a pdf to disk', function () {
+    $path = getTempPath('chrome-save-test.pdf');
+
+    $this->driver->savePdf('<h1>Hello</h1>', null, null, new PdfOptions, $path);
+
+    expect(file_exists($path))->toBeTrue();
+    expect(file_get_contents($path))->toStartWith('%PDF');
+});
+
+it('generates a pdf with text content', function () {
+    $path = getTempPath('chrome-text-content.pdf');
+
+    $this->driver->savePdf(
+        '<html><body><h1>Invoice #123</h1><p>Total: $99.00</p></body></html>',
+        null,
+        null,
+        new PdfOptions,
+        $path,
+    );
+
+    expect($path)->toContainText(['Invoice', '123', '99']);
+});
+
+it('generates a pdf with a4 format', function () {
+    $options = new PdfOptions;
+    $options->format = 'a4';
+
+    $path = getTempPath('chrome-a4.pdf');
+    $this->driver->savePdf('<html><body><h1>A4 Document</h1></body></html>', null, null, $options, $path);
+
+    expect($path)->toContainText('A4 Document');
+});
+
+it('generates a pdf with header and footer', function () {
+    $options = new PdfOptions;
+
+    $path = getTempPath('chrome-header-footer.pdf');
+    $this->driver->savePdf(
+        '<html><body><h1>Body</h1></body></html>',
+        '<h1>Header</h1>',
+        '<h1>Footer</h1>',
+        $options,
+        $path,
+    );
+
+    expect($path)->toContainText(['Header', 'Footer']);
+});

--- a/tests/Integration/ChromeIntegrationTest.php
+++ b/tests/Integration/ChromeIntegrationTest.php
@@ -4,6 +4,29 @@ use Spatie\LaravelPdf\Drivers\ChromeDriver;
 use Spatie\LaravelPdf\PdfOptions;
 
 beforeEach(function () {
+    $binaries = array_filter([
+        env('LARAVEL_PDF_CHROME_BINARY'),
+        'google-chrome-stable',
+        'google-chrome',
+        'chromium',
+        'chromium-browser',
+    ]);
+
+    $found = false;
+
+    foreach ($binaries as $binary) {
+        $resolved = trim((string) shell_exec('command -v '.escapeshellarg($binary).' 2>/dev/null'));
+
+        if ($resolved && is_executable($resolved)) {
+            $found = true;
+            break;
+        }
+    }
+
+    if (! $found) {
+        $this->markTestSkipped('Chrome or Chromium is not available.');
+    }
+
     $this->driver = new ChromeDriver;
 });
 

--- a/tests/Integration/ChromeIntegrationTest.php
+++ b/tests/Integration/ChromeIntegrationTest.php
@@ -33,55 +33,65 @@ beforeEach(function () {
 });
 
 it('generates a pdf with default options', function () {
-    $result = $this->driver->generatePdf('<h1>Hello</h1>', null, null, new PdfOptions);
+    retryOnFlake(function () {
+        $result = $this->driver->generatePdf('<h1>Hello</h1>', null, null, new PdfOptions);
 
-    expect($result)->toStartWith('%PDF');
-})->flaky();
+        expect($result)->toStartWith('%PDF');
+    });
+});
 
 it('saves a pdf to disk', function () {
-    $path = getTempPath('chrome-save-test.pdf');
+    retryOnFlake(function () {
+        $path = getTempPath('chrome-save-test.pdf');
 
-    $this->driver->savePdf('<h1>Hello</h1>', null, null, new PdfOptions, $path);
+        $this->driver->savePdf('<h1>Hello</h1>', null, null, new PdfOptions, $path);
 
-    expect(file_exists($path))->toBeTrue();
-    expect(file_get_contents($path))->toStartWith('%PDF');
-})->flaky();
+        expect(file_exists($path))->toBeTrue();
+        expect(file_get_contents($path))->toStartWith('%PDF');
+    });
+});
 
 it('generates a pdf with text content', function () {
-    $path = getTempPath('chrome-text-content.pdf');
+    retryOnFlake(function () {
+        $path = getTempPath('chrome-text-content.pdf');
 
-    $this->driver->savePdf(
-        '<html><body><h1>Invoice #123</h1><p>Total: $99.00</p></body></html>',
-        null,
-        null,
-        new PdfOptions,
-        $path,
-    );
+        $this->driver->savePdf(
+            '<html><body><h1>Invoice #123</h1><p>Total: $99.00</p></body></html>',
+            null,
+            null,
+            new PdfOptions,
+            $path,
+        );
 
-    expect($path)->toContainText(['Invoice', '123', '99']);
-})->flaky();
+        expect($path)->toContainText(['Invoice', '123', '99']);
+    });
+});
 
 it('generates a pdf with a4 format', function () {
-    $options = new PdfOptions;
-    $options->format = 'a4';
+    retryOnFlake(function () {
+        $options = new PdfOptions;
+        $options->format = 'a4';
 
-    $path = getTempPath('chrome-a4.pdf');
-    $this->driver->savePdf('<html><body><h1>A4 Document</h1></body></html>', null, null, $options, $path);
+        $path = getTempPath('chrome-a4.pdf');
+        $this->driver->savePdf('<html><body><h1>A4 Document</h1></body></html>', null, null, $options, $path);
 
-    expect($path)->toContainText('A4 Document');
-})->flaky();
+        expect($path)->toContainText('A4 Document');
+    });
+});
 
 it('generates a pdf with header and footer', function () {
-    $options = new PdfOptions;
+    retryOnFlake(function () {
+        $options = new PdfOptions;
 
-    $path = getTempPath('chrome-header-footer.pdf');
-    $this->driver->savePdf(
-        '<html><body><h1>Body</h1></body></html>',
-        '<h1>Header</h1>',
-        '<h1>Footer</h1>',
-        $options,
-        $path,
-    );
+        $path = getTempPath('chrome-header-footer.pdf');
+        $this->driver->savePdf(
+            '<html><body><h1>Body</h1></body></html>',
+            '<h1>Header</h1>',
+            '<h1>Footer</h1>',
+            $options,
+            $path,
+        );
 
-    expect($path)->toContainText(['Header', 'Footer']);
-})->flaky();
+        expect($path)->toContainText(['Header', 'Footer']);
+    });
+});

--- a/tests/Integration/ChromeIntegrationTest.php
+++ b/tests/Integration/ChromeIntegrationTest.php
@@ -27,14 +27,16 @@ beforeEach(function () {
         $this->markTestSkipped('Chrome or Chromium is not available.');
     }
 
-    $this->driver = new ChromeDriver;
+    $this->driver = new ChromeDriver([
+        'no_sandbox' => true,
+    ]);
 });
 
 it('generates a pdf with default options', function () {
     $result = $this->driver->generatePdf('<h1>Hello</h1>', null, null, new PdfOptions);
 
     expect($result)->toStartWith('%PDF');
-});
+})->flaky();
 
 it('saves a pdf to disk', function () {
     $path = getTempPath('chrome-save-test.pdf');
@@ -43,7 +45,7 @@ it('saves a pdf to disk', function () {
 
     expect(file_exists($path))->toBeTrue();
     expect(file_get_contents($path))->toStartWith('%PDF');
-});
+})->flaky();
 
 it('generates a pdf with text content', function () {
     $path = getTempPath('chrome-text-content.pdf');
@@ -57,7 +59,7 @@ it('generates a pdf with text content', function () {
     );
 
     expect($path)->toContainText(['Invoice', '123', '99']);
-});
+})->flaky();
 
 it('generates a pdf with a4 format', function () {
     $options = new PdfOptions;
@@ -67,7 +69,7 @@ it('generates a pdf with a4 format', function () {
     $this->driver->savePdf('<html><body><h1>A4 Document</h1></body></html>', null, null, $options, $path);
 
     expect($path)->toContainText('A4 Document');
-});
+})->flaky();
 
 it('generates a pdf with header and footer', function () {
     $options = new PdfOptions;
@@ -82,4 +84,4 @@ it('generates a pdf with header and footer', function () {
     );
 
     expect($path)->toContainText(['Header', 'Footer']);
-});
+})->flaky();

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -89,6 +89,23 @@ expect()->extend('toHavePageCount', function (int $expectedNumberOfPages) {
     expect($image->getNumberImages())->toBe($expectedNumberOfPages);
 });
 
+function retryOnFlake(callable $callback, int $tries = 3): void
+{
+    for ($attempt = 1; $attempt <= $tries; $attempt++) {
+        try {
+            $callback();
+
+            return;
+        } catch (Throwable $exception) {
+            if ($attempt === $tries) {
+                throw $exception;
+            }
+
+            usleep(200_000);
+        }
+    }
+}
+
 function convertPdfToImage(string $pdfPath): string
 {
     $imagePath = getTempPath('test'.'.png');

--- a/tests/Unit/ChromeDriverTest.php
+++ b/tests/Unit/ChromeDriverTest.php
@@ -1,0 +1,169 @@
+<?php
+
+use Spatie\LaravelPdf\Drivers\ChromeDriver;
+use Spatie\LaravelPdf\Enums\Orientation;
+use Spatie\LaravelPdf\PdfOptions;
+
+it('builds default browser options', function () {
+    $driver = new ChromeDriver;
+
+    $options = invade($driver)->buildBrowserOptions();
+
+    expect($options)->toBe([
+        'headless' => true,
+    ]);
+});
+
+it('builds configured browser options', function () {
+    $driver = new ChromeDriver([
+        'no_sandbox' => true,
+        'startup_timeout' => 45,
+        'user_data_dir' => '/tmp/chrome-profile',
+        'custom_flags' => ['--disable-gpu', '--lang=en-US'],
+        'env_variables' => ['HOME' => '/tmp/chrome-home'],
+    ]);
+
+    $options = invade($driver)->buildBrowserOptions();
+
+    expect($options)->toBe([
+        'headless' => true,
+        'noSandbox' => true,
+        'startupTimeout' => 45,
+        'userDataDir' => '/tmp/chrome-profile',
+        'customFlags' => ['--disable-gpu', '--lang=en-US'],
+        'envVariables' => ['HOME' => '/tmp/chrome-home'],
+    ]);
+});
+
+it('builds default pdf options', function () {
+    $driver = new ChromeDriver;
+
+    $pdfOptions = invade($driver)->buildPdfOptions(null, null, new PdfOptions);
+
+    expect($pdfOptions)->toBe([
+        'printBackground' => true,
+    ]);
+});
+
+it('maps format to paper dimensions', function () {
+    $driver = new ChromeDriver;
+
+    $options = new PdfOptions;
+    $options->format = 'A4';
+
+    $pdfOptions = invade($driver)->buildPdfOptions(null, null, $options);
+
+    expect($pdfOptions)->toMatchArray([
+        'printBackground' => true,
+        'paperWidth' => 8.27,
+        'paperHeight' => 11.7,
+    ]);
+});
+
+it('maps custom paper size and margins to inches', function () {
+    $driver = new ChromeDriver;
+
+    $options = new PdfOptions;
+    $options->paperSize = [
+        'width' => 100,
+        'height' => 200,
+        'unit' => 'mm',
+    ];
+    $options->margins = [
+        'top' => 10,
+        'right' => 20,
+        'bottom' => 30,
+        'left' => 40,
+        'unit' => 'mm',
+    ];
+
+    $pdfOptions = invade($driver)->buildPdfOptions(null, null, $options);
+
+    expect(round($pdfOptions['paperWidth'], 5))->toBe(3.93701);
+    expect(round($pdfOptions['paperHeight'], 5))->toBe(7.87402);
+    expect(round($pdfOptions['marginTop'], 6))->toBe(0.393701);
+    expect(round($pdfOptions['marginRight'], 6))->toBe(0.787402);
+    expect(round($pdfOptions['marginBottom'], 6))->toBe(1.181103);
+    expect(round($pdfOptions['marginLeft'], 6))->toBe(1.574804);
+});
+
+it('falls back to millimeters for unknown units', function () {
+    $driver = new ChromeDriver;
+
+    $options = new PdfOptions;
+    $options->paperSize = [
+        'width' => 10,
+        'height' => 20,
+        'unit' => 'unknown',
+    ];
+    $options->margins = [
+        'top' => 1,
+        'right' => 2,
+        'bottom' => 3,
+        'left' => 4,
+        'unit' => 'unknown',
+    ];
+
+    $pdfOptions = invade($driver)->buildPdfOptions(null, null, $options);
+
+    expect(round($pdfOptions['paperWidth'], 6))->toBe(0.393701);
+    expect(round($pdfOptions['paperHeight'], 6))->toBe(0.787402);
+    expect(round($pdfOptions['marginTop'], 7))->toBe(0.0393701);
+    expect(round($pdfOptions['marginRight'], 7))->toBe(0.0787402);
+    expect(round($pdfOptions['marginBottom'], 7))->toBe(0.1181103);
+    expect(round($pdfOptions['marginLeft'], 7))->toBe(0.1574804);
+});
+
+it('maps landscape scale page and ranges', function () {
+    $driver = new ChromeDriver;
+
+    $options = new PdfOptions;
+    $options->orientation = Orientation::Landscape->value;
+    $options->scale = 0.75;
+    $options->pageRanges = '1-3';
+
+    $pdfOptions = invade($driver)->buildPdfOptions(null, null, $options);
+
+    expect($pdfOptions)->toMatchArray([
+        'landscape' => true,
+        'scale' => 0.75,
+        'pageRanges' => '1-3',
+    ]);
+});
+
+it('enables header and footer templates when provided', function () {
+    $driver = new ChromeDriver;
+
+    $pdfOptions = invade($driver)->buildPdfOptions(
+        '<div>Header</div>',
+        '<div>Footer</div>',
+        new PdfOptions,
+    );
+
+    expect($pdfOptions)->toMatchArray([
+        'displayHeaderFooter' => true,
+        'headerTemplate' => '<div>Header</div>',
+        'footerTemplate' => '<div>Footer</div>',
+    ]);
+});
+
+it('enables header footer display when only one template is provided', function () {
+    $driver = new ChromeDriver;
+
+    $headerOptions = invade($driver)->buildPdfOptions('<div>Header</div>', null, new PdfOptions);
+    $footerOptions = invade($driver)->buildPdfOptions(null, '<div>Footer</div>', new PdfOptions);
+
+    expect($headerOptions)->toMatchArray([
+        'displayHeaderFooter' => true,
+        'headerTemplate' => '<div>Header</div>',
+    ]);
+
+    expect($headerOptions)->not->toHaveKey('footerTemplate');
+
+    expect($footerOptions)->toMatchArray([
+        'displayHeaderFooter' => true,
+        'footerTemplate' => '<div>Footer</div>',
+    ]);
+
+    expect($footerOptions)->not->toHaveKey('headerTemplate');
+});


### PR DESCRIPTION
This PR implement [chrome-php/chrome](https://github.com/chrome-php/chrome) library driver. It provides a way to control a headless Chrome/Chromium instance from PHP with only Chrome executable requirement.

Changes:

- Added chrome-php/chrome driver and related configuration
- Added unit and integration tests
- Added relevant documentation