### PR TITLE
Add fallback driver with health cache and pdf:health command

### DIFF
--- a/config/laravel-pdf.php
+++ b/config/laravel-pdf.php
@@ -10,6 +10,55 @@ return [
     'driver' => env('LARAVEL_PDF_DRIVER', 'browsershot'),
 
     /*
+     * Configuration for the driver fallback chain.
+     */
+    'fallback' => [
+        /*
+         * Ordered list of drivers to try when the default driver fails.
+         * Empty array = no fallback (default behavior).
+         * Example: ['browsershot', 'dompdf']
+         */
+        'drivers' => [],
+
+        /*
+         * Allowlist of exception FQCNs that trigger a fallback.
+         * If non-empty, only these exceptions will cause the next driver to be tried.
+         * Takes precedence over `except_exceptions` when both are configured.
+         * Example: ['GuzzleHttp\Exception\ConnectException']
+         */
+        'only_on_exceptions' => [],
+
+        /*
+         * Denylist of exception FQCNs that must NOT trigger a fallback.
+         * If non-empty (and `only_on_exceptions` is empty), any other exception
+         * triggers the fallback while these are re-thrown as-is.
+         * Example: ['Illuminate\View\ViewException']
+         */
+        'except_exceptions' => [],
+
+        /*
+         * After a driver fails, mark it unhealthy in the cache so that subsequent
+         * requests skip it without re-attempting until the TTL expires.
+         */
+        'health_cache' => [
+            /*
+             * Seconds to keep a driver marked as unhealthy. Zero disables the health cache.
+             */
+            'ttl' => env('LARAVEL_PDF_FALLBACK_HEALTH_TTL', 0),
+
+            /*
+             * Cache key prefix.
+             */
+            'key_prefix' => 'laravel_pdf_driver_health_',
+
+            /*
+             * Cache store to use. Null uses the application's default store.
+             */
+            'store' => env('LARAVEL_PDF_FALLBACK_HEALTH_STORE'),
+        ],
+    ],
+
+    /*
      * The job class used for queued PDF generation.
      * You can replace this with your own class that extends GeneratePdfJob
      * to customize things like $tries, $timeout, $backoff, or default queue.

--- a/config/laravel-pdf.php
+++ b/config/laravel-pdf.php
@@ -15,10 +15,11 @@ return [
     'fallback' => [
         /*
          * Ordered list of drivers to try when the default driver fails.
-         * Empty array = no fallback (default behavior).
-         * Example: ['browsershot', 'dompdf']
+         * Set LARAVEL_PDF_FALLBACK_DRIVERS to a comma-separated list (e.g.
+         * "dompdf,chrome"), or override this array directly.
+         * Empty = no fallback (default behavior).
          */
-        'drivers' => [],
+        'drivers' => array_filter(explode(',', env('LARAVEL_PDF_FALLBACK_DRIVERS', ''))),
 
         /*
          * Allowlist of exception FQCNs that trigger a fallback.

--- a/docs/advanced-usage/driver-fallback-chain.md
+++ b/docs/advanced-usage/driver-fallback-chain.md
@@ -1,0 +1,137 @@
+---
+title: Driver fallback chain
+weight: 5
+---
+
+The fallback option lets you configure an ordered chain of drivers. When the primary driver fails, the next driver in the chain is tried automatically — without changing any application code. The chain supports any number of drivers.
+
+This is useful when the primary driver depends on something that can fail outside of your application's control, for example:
+
+- The primary is an external HTTP service (`cloudflare`, `gotenberg`) that may rate-limit, time out, or rotate credentials.
+- The primary requires Chrome or Node.js (`browsershot`, `chrome`) and the binary may be missing or misconfigured on some environments (serverless, shared hosting, fresh containers).
+
+The DOMPDF driver is a good last entry in any chain — it runs entirely in PHP and has no external dependencies. The output will not look identical to a Chromium-based driver (see [Using the DOMPDF driver](/docs/laravel-pdf/v2/drivers/using-the-dompdf-driver) for its limitations), but it will produce a usable PDF when nothing else works.
+
+## Basic usage
+
+Set the chain in `config/laravel-pdf.php`:
+
+```php
+'driver' => 'gotenberg',
+
+'fallback' => [
+    'drivers' => ['chrome', 'dompdf'],
+],
+```
+
+Or use the `LARAVEL_PDF_FALLBACK_DRIVERS` environment variable, which accepts a comma-separated list:
+
+```env
+LARAVEL_PDF_DRIVER=gotenberg
+LARAVEL_PDF_FALLBACK_DRIVERS=chrome,dompdf
+```
+
+When the variable is empty or unset, no chain is built and the package behaves as before.
+
+## Per-PDF fluent API
+
+You can also configure the chain on a single PDF using the `fallback` method:
+
+```php
+use Spatie\LaravelPdf\Facades\Pdf;
+
+Pdf::view('pdfs.invoice', ['invoice' => $invoice])
+    ->driver('cloudflare')
+    ->fallback('dompdf')
+    ->save('invoice.pdf');
+
+// Or pass an ordered list:
+Pdf::view('pdfs.invoice', ['invoice' => $invoice])
+    ->driver('gotenberg')
+    ->fallback(['chrome', 'dompdf'])
+    ->save('invoice.pdf');
+```
+
+The chain always starts with the driver returned by `driver()` (or the default driver from config), followed by the drivers passed to `fallback()`.
+
+## Filtering which exceptions trigger a fallback
+
+By default, every exception thrown by a driver triggers the fallback. Two options let you narrow this down:
+
+```php
+'fallback' => [
+    'drivers' => ['chrome', 'dompdf'],
+
+    'only_on_exceptions' => [
+        \GuzzleHttp\Exception\ConnectException::class,
+    ],
+
+    'except_exceptions' => [
+        \Illuminate\View\ViewException::class,
+    ],
+],
+```
+
+- **only_on_exceptions**: allowlist of exception classes that trigger a fallback. When non-empty, only these exceptions cause the next driver to be tried — everything else is re-thrown.
+- **except_exceptions**: denylist of exception classes that are always re-thrown as-is.
+
+When both are set, `only_on_exceptions` takes precedence. Leave both empty to fall back on any exception.
+
+## Skipping unhealthy drivers
+
+If a driver is failing, attempting it on every request can be wasteful — for example a Gotenberg container that's down may spend several seconds timing out before the fallback runs. The optional health cache marks a driver as unhealthy after a failure and skips it for a configurable period:
+
+```php
+'fallback' => [
+    'drivers' => ['gotenberg', 'dompdf'],
+
+    'health_cache' => [
+        'ttl'        => env('LARAVEL_PDF_FALLBACK_HEALTH_TTL', 0),
+        'key_prefix' => 'laravel_pdf_driver_health_',
+        'store'      => env('LARAVEL_PDF_FALLBACK_HEALTH_STORE'),
+    ],
+],
+```
+
+- **ttl**: seconds a failing driver stays marked unhealthy. Set to `0` to disable the cache.
+- **key_prefix**: cache key prefix. Override per-tenant if you share a cache store across applications.
+- **store**: cache store to use. Defaults to the application's default store when null.
+
+The health cache is disabled by default. Set a TTL like `600` to skip a driver for ten minutes after it fails.
+
+## Inspecting failures
+
+When the entire chain fails, a `CouldNotGeneratePdf` is thrown carrying the full context:
+
+```php
+use Spatie\LaravelPdf\Exceptions\CouldNotGeneratePdf;
+
+try {
+    Pdf::view('pdfs.invoice', $data)->save('invoice.pdf');
+} catch (CouldNotGeneratePdf $e) {
+    $e->attemptedDrivers;   // ['gotenberg', 'chrome', 'dompdf']
+    $e->driverExceptions;   // ['gotenberg' => ConnectException, ...]
+    $e->getPrevious();      // the last driver's exception
+}
+```
+
+Each individual driver failure is also reported through Laravel's exception handler as it happens, so failures show up in your normal log channels even when a later driver in the chain succeeds.
+
+## Checking driver health from the CLI
+
+The `pdf:health` Artisan command pings every configured driver and reports whether it can generate a small sample PDF:
+
+```bash
+php artisan pdf:health
+```
+
+```
+  INFO  Checking PDF driver health.
+
+  gotenberg (primary) ................................... healthy 362ms
+  dompdf (fallback) ..................................... healthy  18ms
+
+  All 2 driver(s) are healthy.
+```
+
+The command exits with code `0` when every driver is healthy and `1` otherwise. Use it in a CI job, a readiness probe, or a periodic cron to catch broken drivers early.

--- a/docs/drivers/configuration.md
+++ b/docs/drivers/configuration.md
@@ -25,6 +25,32 @@ The `driver` option determines which PDF generation backend to use:
 
 Supported values: `browsershot`, `chrome`, `cloudflare`, `dompdf`, `gotenberg`, `weasyprint`.
 
+## Fallback Configuration
+
+You can configure an ordered chain of drivers to try when the primary driver fails:
+
+```php
+'fallback' => [
+    'drivers' => array_filter(explode(',', env('LARAVEL_PDF_FALLBACK_DRIVERS', ''))),
+    'only_on_exceptions' => [],
+    'except_exceptions' => [],
+    'health_cache' => [
+        'ttl' => env('LARAVEL_PDF_FALLBACK_HEALTH_TTL', 0),
+        'key_prefix' => 'laravel_pdf_driver_health_',
+        'store' => env('LARAVEL_PDF_FALLBACK_HEALTH_STORE'),
+    ],
+],
+```
+
+- **drivers**: ordered list of fallback drivers. Empty disables the chain. Can also be set via `LARAVEL_PDF_FALLBACK_DRIVERS` as a comma-separated list.
+- **only_on_exceptions**: allowlist of exception classes that trigger a fallback. When non-empty, takes precedence over `except_exceptions`.
+- **except_exceptions**: denylist of exception classes that are always re-thrown as-is.
+- **health_cache.ttl**: seconds a failing driver stays marked unhealthy. `0` disables the cache.
+- **health_cache.key_prefix**: cache key prefix.
+- **health_cache.store**: cache store name. Null uses the application's default store.
+
+See [Driver fallback chain](/docs/laravel-pdf/v2/advanced-usage/driver-fallback-chain) for full usage and examples.
+
 ## Browsershot Configuration
 
 Configure paths to Node.js, npm, Chrome, and other binaries used by the Browsershot driver:
@@ -123,6 +149,11 @@ You can use environment variables to configure PDF generation:
 ```env
 # Driver selection
 LARAVEL_PDF_DRIVER=browsershot
+
+# Fallback chain (comma-separated)
+LARAVEL_PDF_FALLBACK_DRIVERS=chrome,dompdf
+LARAVEL_PDF_FALLBACK_HEALTH_TTL=600
+LARAVEL_PDF_FALLBACK_HEALTH_STORE=redis
 
 # Browsershot settings
 LARAVEL_PDF_NODE_BINARY=/usr/local/bin/node

--- a/src/Commands/PdfHealthCommand.php
+++ b/src/Commands/PdfHealthCommand.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Spatie\LaravelPdf\Commands;
+
+use Illuminate\Console\Command;
+use Spatie\LaravelPdf\PdfOptions;
+use Spatie\LaravelPdf\PdfServiceProvider;
+use Throwable;
+
+class PdfHealthCommand extends Command
+{
+    protected $signature = 'pdf:health';
+
+    protected $description = 'Check the health of the configured PDF driver and all fallback drivers';
+
+    public function handle(): int
+    {
+        $primary = config('laravel-pdf.driver', 'browsershot');
+        $fallbacks = config('laravel-pdf.fallback.drivers', []);
+
+        $names = array_values(array_unique([$primary, ...$fallbacks]));
+
+        $failed = 0;
+
+        foreach ($names as $name) {
+            $row = $this->checkDriver($name, $primary);
+            $this->renderRow($row);
+
+            if (! $row['healthy']) {
+                $failed++;
+            }
+        }
+
+        $this->newLine();
+
+        $total = count($names);
+
+        if ($failed === 0) {
+            $this->info("All {$total} driver(s) are healthy.");
+
+            return self::SUCCESS;
+        }
+
+        $this->error("{$failed} of {$total} driver(s) failed.");
+
+        return self::FAILURE;
+    }
+
+    /**
+     * @return array{name: string, role: string, healthy: bool, time: string, error: ?string}
+     */
+    protected function checkDriver(string $name, string $primary): array
+    {
+        $role = $name === $primary ? 'primary' : 'fallback';
+        $start = hrtime(true);
+
+        try {
+            $driver = PdfServiceProvider::resolveDriverByName($name);
+            $driver->generatePdf('<h1>Hello World</h1>', null, null, new PdfOptions);
+
+            return [
+                'name' => $name,
+                'role' => $role,
+                'healthy' => true,
+                'time' => $this->formatElapsed($start),
+                'error' => null,
+            ];
+        } catch (Throwable $e) {
+            return [
+                'name' => $name,
+                'role' => $role,
+                'healthy' => false,
+                'time' => $this->formatElapsed($start),
+                'error' => $e->getMessage(),
+            ];
+        }
+    }
+
+    /**
+     * @param  array{name: string, role: string, healthy: bool, time: string, error: ?string}  $row
+     */
+    protected function renderRow(array $row): void
+    {
+        $label = "{$row['name']} <fg=gray>({$row['role']})</>";
+        $status = $row['healthy']
+            ? "<info>healthy</info> <fg=gray>{$row['time']}</>"
+            : "<error>failed</error> <fg=gray>{$row['time']}</> — {$row['error']}";
+
+        $this->components->twoColumnDetail($label, $status);
+    }
+
+    protected function formatElapsed(int $start): string
+    {
+        return sprintf('%.0fms', (hrtime(true) - $start) / 1e6);
+    }
+}

--- a/src/Commands/PdfHealthCommand.php
+++ b/src/Commands/PdfHealthCommand.php
@@ -20,6 +20,9 @@ class PdfHealthCommand extends Command
 
         $names = array_values(array_unique([$primary, ...$fallbacks]));
 
+        $this->newLine();
+        $this->components->info('Checking PDF driver health');
+
         $failed = 0;
 
         foreach ($names as $name) {

--- a/src/Drivers/FallbackDriver.php
+++ b/src/Drivers/FallbackDriver.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Spatie\LaravelPdf\Drivers;
+
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Spatie\LaravelPdf\Exceptions\CouldNotGeneratePdf;
+use Spatie\LaravelPdf\PdfOptions;
+use Throwable;
+
+class FallbackDriver implements PdfDriver
+{
+    /**
+     * @param  array<string, PdfDriver>  $drivers
+     * @param  array<int, class-string<Throwable>>  $onlyOnExceptions
+     * @param  array<int, class-string<Throwable>>  $exceptExceptions
+     */
+    public function __construct(
+        protected array $drivers,
+        protected ExceptionHandler $exceptionHandler,
+        protected array $onlyOnExceptions = [],
+        protected array $exceptExceptions = [],
+        protected ?CacheRepository $cacheRepository = null,
+        protected int $healthCacheTtl = 0,
+        protected string $healthCacheKeyPrefix = 'laravel_pdf_driver_health_',
+    ) {}
+
+    /**
+     * @return array<string, PdfDriver>
+     */
+    public function getDrivers(): array
+    {
+        return $this->drivers;
+    }
+
+    public function generatePdf(string $html, ?string $headerHtml, ?string $footerHtml, PdfOptions $options): string
+    {
+        return $this->run(fn (PdfDriver $driver) => $driver->generatePdf($html, $headerHtml, $footerHtml, $options));
+    }
+
+    public function savePdf(string $html, ?string $headerHtml, ?string $footerHtml, PdfOptions $options, string $path): void
+    {
+        $this->run(function (PdfDriver $driver) use ($html, $headerHtml, $footerHtml, $options, $path): bool {
+            $driver->savePdf($html, $headerHtml, $footerHtml, $options, $path);
+
+            return true;
+        });
+    }
+
+    /**
+     * @template T
+     *
+     * @param  callable(PdfDriver): T  $callback
+     * @return T
+     */
+    protected function run(callable $callback): mixed
+    {
+        $exceptions = [];
+        $attemptedNames = [];
+
+        foreach ($this->drivers as $driverName => $driver) {
+            if (! $this->isDriverHealthy($driverName)) {
+                continue;
+            }
+
+            $attemptedNames[] = $driverName;
+
+            try {
+                return $callback($driver);
+            } catch (Throwable $exception) {
+                if (! $this->shouldFallback($exception)) {
+                    throw $exception;
+                }
+
+                $exceptions[$driverName] = $exception;
+                $this->markDriverUnhealthy($driverName);
+                $this->exceptionHandler->report($exception);
+            }
+        }
+
+        if ($attemptedNames === []) {
+            throw CouldNotGeneratePdf::allDriversUnhealthy(array_keys($this->drivers));
+        }
+
+        throw CouldNotGeneratePdf::allFallbackFailed($attemptedNames, $exceptions);
+    }
+
+    protected function shouldFallback(Throwable $exception): bool
+    {
+        if ($this->onlyOnExceptions !== []) {
+            foreach ($this->onlyOnExceptions as $allowed) {
+                if ($exception instanceof $allowed) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        foreach ($this->exceptExceptions as $denied) {
+            if ($exception instanceof $denied) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    protected function isDriverHealthy(string $driverName): bool
+    {
+        if (! $this->healthCacheEnabled()) {
+            return true;
+        }
+
+        return ! $this->cacheRepository->has($this->healthCacheKey($driverName));
+    }
+
+    protected function markDriverUnhealthy(string $driverName): void
+    {
+        if (! $this->healthCacheEnabled()) {
+            return;
+        }
+
+        $this->cacheRepository->put($this->healthCacheKey($driverName), true, $this->healthCacheTtl);
+    }
+
+    protected function healthCacheEnabled(): bool
+    {
+        return $this->cacheRepository !== null && $this->healthCacheTtl > 0;
+    }
+
+    protected function healthCacheKey(string $driverName): string
+    {
+        return $this->healthCacheKeyPrefix.$driverName;
+    }
+}

--- a/src/Exceptions/CouldNotGeneratePdf.php
+++ b/src/Exceptions/CouldNotGeneratePdf.php
@@ -3,9 +3,52 @@
 namespace Spatie\LaravelPdf\Exceptions;
 
 use Exception;
+use Throwable;
 
 class CouldNotGeneratePdf extends Exception
 {
+    /** @var array<int, string> */
+    public array $attemptedDrivers = [];
+
+    /** @var array<string, Throwable> */
+    public array $driverExceptions = [];
+
+    /**
+     * @param  array<int, string>  $drivers
+     * @param  array<string, Throwable>  $exceptions
+     */
+    public static function allFallbackFailed(array $drivers, array $exceptions): self
+    {
+        $list = implode(', ', $drivers);
+        $previous = end($exceptions) ?: null;
+
+        $exception = new self(
+            "PDF generation failed after trying all configured drivers: {$list}.",
+            previous: $previous ?: null,
+        );
+
+        $exception->attemptedDrivers = $drivers;
+        $exception->driverExceptions = $exceptions;
+
+        return $exception;
+    }
+
+    /**
+     * @param  array<int, string>  $drivers
+     */
+    public static function allDriversUnhealthy(array $drivers): self
+    {
+        $list = implode(', ', $drivers);
+
+        $exception = new self(
+            "All configured PDF drivers are currently marked unhealthy: {$list}."
+        );
+
+        $exception->attemptedDrivers = $drivers;
+
+        return $exception;
+    }
+
     public static function browsershotNotInstalled(): self
     {
         return new self(

--- a/src/PdfBuilder.php
+++ b/src/PdfBuilder.php
@@ -79,6 +79,9 @@ class PdfBuilder implements Attachable, Responsable
 
     protected ?string $driverName = null;
 
+    /** @var array<int, string> */
+    protected array $fallbackDrivers = [];
+
     public function setDriver(PdfDriver $driver): self
     {
         $this->driver = $driver;
@@ -95,9 +98,23 @@ class PdfBuilder implements Attachable, Responsable
         return $this;
     }
 
+    /**
+     * @param  string|array<int, string>  $drivers
+     */
+    public function fallback(string|array $drivers): self
+    {
+        $this->fallbackDrivers = array_values((array) $drivers);
+
+        return $this;
+    }
+
     protected function getDriver(): PdfDriver
     {
-        if ($this->driver) {
+        if ($this->fallbackDrivers !== []) {
+            $primary = $this->driverName ?? config('laravel-pdf.driver', 'browsershot');
+
+            $driver = PdfServiceProvider::buildFallbackDriver([$primary, ...$this->fallbackDrivers]);
+        } elseif ($this->driver) {
             $driver = $this->driver;
         } elseif ($this->driverName) {
             $driver = app("laravel-pdf.driver.{$this->driverName}");
@@ -514,6 +531,14 @@ class PdfBuilder implements Attachable, Responsable
 
     protected function configureBrowsershotDriver(PdfDriver $driver): void
     {
+        if ($driver instanceof Drivers\FallbackDriver) {
+            foreach ($driver->getDrivers() as $inner) {
+                $this->configureBrowsershotDriver($inner);
+            }
+
+            return;
+        }
+
         if (! $driver instanceof Drivers\BrowsershotDriver) {
             return;
         }

--- a/src/PdfServiceProvider.php
+++ b/src/PdfServiceProvider.php
@@ -2,13 +2,18 @@
 
 namespace Spatie\LaravelPdf;
 
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Support\Facades\Blade;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Spatie\LaravelPdf\Commands\PdfHealthCommand;
 use Spatie\LaravelPdf\Drivers\BrowsershotDriver;
 use Spatie\LaravelPdf\Drivers\ChromeDriver;
 use Spatie\LaravelPdf\Drivers\CloudflareDriver;
 use Spatie\LaravelPdf\Drivers\DomPdfDriver;
+use Spatie\LaravelPdf\Drivers\FallbackDriver;
 use Spatie\LaravelPdf\Drivers\GotenbergDriver;
 use Spatie\LaravelPdf\Drivers\PdfDriver;
 use Spatie\LaravelPdf\Drivers\WeasyPrintDriver;
@@ -20,7 +25,8 @@ class PdfServiceProvider extends PackageServiceProvider
     {
         $package
             ->name('laravel-pdf')
-            ->hasConfigFile('laravel-pdf');
+            ->hasConfigFile('laravel-pdf')
+            ->hasCommand(PdfHealthCommand::class);
     }
 
     public function registeringPackage(): void
@@ -52,16 +58,68 @@ class PdfServiceProvider extends PackageServiceProvider
         $this->app->singleton(PdfDriver::class, function () {
             $driverName = config('laravel-pdf.driver', 'browsershot');
 
-            return match ($driverName) {
-                'browsershot' => app('laravel-pdf.driver.browsershot'),
-                'cloudflare' => app('laravel-pdf.driver.cloudflare'),
-                'dompdf' => app('laravel-pdf.driver.dompdf'),
-                'gotenberg' => app('laravel-pdf.driver.gotenberg'),
-                'weasyprint' => app('laravel-pdf.driver.weasyprint'),
-                'chrome' => app('laravel-pdf.driver.chrome'),
-                default => throw InvalidDriver::unknown($driverName),
-            };
+            $primary = self::resolveDriverByName($driverName);
+
+            $fallbackNames = config('laravel-pdf.fallback.drivers', []);
+
+            if (! is_array($fallbackNames) || $fallbackNames === []) {
+                return $primary;
+            }
+
+            return self::buildFallbackDriver([$driverName, ...$fallbackNames]);
         });
+    }
+
+    public static function resolveDriverByName(string $driverName): PdfDriver
+    {
+        return match ($driverName) {
+            'browsershot' => app('laravel-pdf.driver.browsershot'),
+            'cloudflare' => app('laravel-pdf.driver.cloudflare'),
+            'dompdf' => app('laravel-pdf.driver.dompdf'),
+            'gotenberg' => app('laravel-pdf.driver.gotenberg'),
+            'weasyprint' => app('laravel-pdf.driver.weasyprint'),
+            'chrome' => app('laravel-pdf.driver.chrome'),
+            default => throw InvalidDriver::unknown($driverName),
+        };
+    }
+
+    /**
+     * @param  array<int, string>  $names
+     */
+    public static function buildFallbackDriver(array $names): FallbackDriver
+    {
+        $names = array_values(array_unique($names));
+
+        $drivers = [];
+        foreach ($names as $name) {
+            $drivers[$name] = self::resolveDriverByName($name);
+        }
+
+        $fallbackConfig = config('laravel-pdf.fallback', []);
+
+        $cacheTtl = (int) ($fallbackConfig['health_cache']['ttl'] ?? 0);
+        $cacheRepository = $cacheTtl > 0
+            ? self::resolveCacheRepository($fallbackConfig['health_cache']['store'] ?? null)
+            : null;
+
+        return new FallbackDriver(
+            drivers: $drivers,
+            exceptionHandler: app(ExceptionHandler::class),
+            onlyOnExceptions: $fallbackConfig['only_on_exceptions'] ?? [],
+            exceptExceptions: $fallbackConfig['except_exceptions'] ?? [],
+            cacheRepository: $cacheRepository,
+            healthCacheTtl: $cacheTtl,
+            healthCacheKeyPrefix: $fallbackConfig['health_cache']['key_prefix'] ?? 'laravel_pdf_driver_health_',
+        );
+    }
+
+    protected static function resolveCacheRepository(?string $store): ?CacheRepository
+    {
+        if (! app()->bound(CacheFactory::class)) {
+            return null;
+        }
+
+        return app(CacheFactory::class)->store($store);
     }
 
     public function bootingPackage()

--- a/tests/Integration/FallbackIntegrationTest.php
+++ b/tests/Integration/FallbackIntegrationTest.php
@@ -1,0 +1,196 @@
+<?php
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Spatie\LaravelPdf\Drivers\FallbackDriver;
+use Spatie\LaravelPdf\Exceptions\CouldNotGeneratePdf;
+use Spatie\LaravelPdf\Facades\Pdf;
+
+beforeEach(function () {
+    forgetPdfDriverInstances();
+
+    Config::set('laravel-pdf.fallback', [
+        'drivers' => [],
+        'only_on_exceptions' => [],
+        'except_exceptions' => [],
+        'health_cache' => [
+            'ttl' => 0,
+            'key_prefix' => 'laravel_pdf_driver_health_',
+            'store' => null,
+        ],
+    ]);
+});
+
+it('uses fluent fallback() to build a FallbackDriver chain', function () {
+    bindFakeDriver('cloudflare', fakePdfDriver(new RuntimeException('cf-down')));
+    $dompdf = fakePdfDriver('dompdf-output');
+    bindFakeDriver('dompdf', $dompdf);
+
+    $path = getTempPath('fluent-fallback.pdf');
+
+    Pdf::html('<h1>Hi</h1>')
+        ->driver('cloudflare')
+        ->fallback('dompdf')
+        ->save($path);
+
+    expect(file_get_contents($path))->toBe('dompdf-output');
+    expect($dompdf->saveCalls)->toBe(1);
+});
+
+it('respects global fallback_drivers config without using the fluent method', function () {
+    Config::set('laravel-pdf.driver', 'cloudflare');
+    Config::set('laravel-pdf.fallback.drivers', ['dompdf']);
+
+    bindFakeDriver('cloudflare', fakePdfDriver(new RuntimeException('cf-down')));
+    $dompdf = fakePdfDriver('dompdf-output');
+    bindFakeDriver('dompdf', $dompdf);
+
+    $path = getTempPath('global-fallback.pdf');
+
+    Pdf::html('<h1>Hi</h1>')->save($path);
+
+    expect(file_get_contents($path))->toBe('dompdf-output');
+});
+
+it('fluent fallback() takes precedence over global fallback_drivers config', function () {
+    Config::set('laravel-pdf.fallback.drivers', ['gotenberg']);
+
+    bindFakeDriver('cloudflare', fakePdfDriver(new RuntimeException('cf-down')));
+    bindFakeDriver('gotenberg', fakePdfDriver(new RuntimeException('gotenberg-down')));
+    $dompdf = fakePdfDriver('chosen');
+    bindFakeDriver('dompdf', $dompdf);
+
+    $path = getTempPath('precedence-fallback.pdf');
+
+    Pdf::html('<h1>Hi</h1>')
+        ->driver('cloudflare')
+        ->fallback('dompdf')
+        ->save($path);
+
+    expect(file_get_contents($path))->toBe('chosen');
+    expect($dompdf->saveCalls)->toBe(1);
+});
+
+it('returns the original driver instance when no fallback is configured', function () {
+    Config::set('laravel-pdf.driver', 'dompdf');
+
+    $dompdf = fakePdfDriver('only-dompdf');
+    bindFakeDriver('dompdf', $dompdf);
+
+    $path = getTempPath('no-fallback.pdf');
+
+    Pdf::html('<h1>Hi</h1>')->save($path);
+
+    expect(file_get_contents($path))->toBe('only-dompdf');
+});
+
+it('accepts both string and array in fallback()', function () {
+    bindFakeDriver('cloudflare', fakePdfDriver(new RuntimeException('cf-down')));
+    bindFakeDriver('chrome', fakePdfDriver(new RuntimeException('chrome-down')));
+    $dompdf = fakePdfDriver('final');
+    bindFakeDriver('dompdf', $dompdf);
+
+    $path = getTempPath('array-fallback.pdf');
+
+    Pdf::html('<h1>Hi</h1>')
+        ->driver('cloudflare')
+        ->fallback(['chrome', 'dompdf'])
+        ->save($path);
+
+    expect(file_get_contents($path))->toBe('final');
+});
+
+it('passes only_on_exceptions config through to FallbackDriver', function () {
+    Config::set('laravel-pdf.driver', 'cloudflare');
+    Config::set('laravel-pdf.fallback.drivers', ['dompdf']);
+    Config::set('laravel-pdf.fallback.only_on_exceptions', [LogicException::class]);
+
+    bindFakeDriver('cloudflare', fakePdfDriver(new RuntimeException('not-allowed')));
+    bindFakeDriver('dompdf', fakePdfDriver('should-not-be-used'));
+
+    $path = getTempPath('only-on.pdf');
+
+    expect(fn () => Pdf::html('<h1>Hi</h1>')->save($path))
+        ->toThrow(RuntimeException::class, 'not-allowed');
+});
+
+it('passes except_exceptions config through to FallbackDriver', function () {
+    Config::set('laravel-pdf.driver', 'cloudflare');
+    Config::set('laravel-pdf.fallback.drivers', ['dompdf']);
+    Config::set('laravel-pdf.fallback.except_exceptions', [LogicException::class]);
+
+    bindFakeDriver('cloudflare', fakePdfDriver(new LogicException('blocked')));
+    bindFakeDriver('dompdf', fakePdfDriver('should-not-be-used'));
+
+    $path = getTempPath('except.pdf');
+
+    expect(fn () => Pdf::html('<h1>Hi</h1>')->save($path))
+        ->toThrow(LogicException::class, 'blocked');
+});
+
+it('passes health_cache.ttl through to FallbackDriver and persists health state', function () {
+    Cache::store('array')->flush();
+
+    Config::set('cache.default', 'array');
+    Config::set('laravel-pdf.driver', 'cloudflare');
+    Config::set('laravel-pdf.fallback.drivers', ['dompdf']);
+    Config::set('laravel-pdf.fallback.health_cache.ttl', 600);
+
+    bindFakeDriver('cloudflare', fakePdfDriver(new RuntimeException('cf-down')));
+    bindFakeDriver('dompdf', fakePdfDriver('ok'));
+
+    Pdf::html('<h1>Hi</h1>')->save(getTempPath('health-1.pdf'));
+
+    expect(Cache::store('array')->has('laravel_pdf_driver_health_cloudflare'))->toBeTrue();
+});
+
+it('uses the configured key_prefix from fallback config', function () {
+    Cache::store('array')->flush();
+
+    Config::set('cache.default', 'array');
+    Config::set('laravel-pdf.driver', 'cloudflare');
+    Config::set('laravel-pdf.fallback.drivers', ['dompdf']);
+    Config::set('laravel-pdf.fallback.health_cache.ttl', 600);
+    Config::set('laravel-pdf.fallback.health_cache.key_prefix', 'mytenant_pdf_');
+
+    bindFakeDriver('cloudflare', fakePdfDriver(new RuntimeException('cf-down')));
+    bindFakeDriver('dompdf', fakePdfDriver('ok'));
+
+    Pdf::html('<h1>Hi</h1>')->save(getTempPath('health-2.pdf'));
+
+    expect(Cache::store('array')->has('mytenant_pdf_cloudflare'))->toBeTrue();
+});
+
+it('throws CouldNotGeneratePdf with attempted drivers when entire chain fails', function () {
+    Config::set('laravel-pdf.driver', 'cloudflare');
+    Config::set('laravel-pdf.fallback.drivers', ['dompdf', 'gotenberg']);
+
+    bindFakeDriver('cloudflare', fakePdfDriver(new RuntimeException('cf')));
+    bindFakeDriver('dompdf', fakePdfDriver(new RuntimeException('dp')));
+    bindFakeDriver('gotenberg', fakePdfDriver(new RuntimeException('gt')));
+
+    $caught = null;
+    try {
+        Pdf::html('<h1>Hi</h1>')->save(getTempPath('all-fail.pdf'));
+    } catch (CouldNotGeneratePdf $e) {
+        $caught = $e;
+    }
+
+    expect($caught)->not->toBeNull();
+    expect($caught->attemptedDrivers)->toBe(['cloudflare', 'dompdf', 'gotenberg']);
+    expect($caught->driverExceptions)->toHaveKeys(['cloudflare', 'dompdf', 'gotenberg']);
+});
+
+it('builds a FallbackDriver instance via the fluent API', function () {
+    bindFakeDriver('cloudflare', fakePdfDriver('ok'));
+    bindFakeDriver('dompdf', fakePdfDriver('also-ok'));
+
+    $builder = Pdf::html('<h1>Hi</h1>')
+        ->driver('cloudflare')
+        ->fallback('dompdf');
+
+    $driver = invade($builder)->getDriver();
+
+    expect($driver)->toBeInstanceOf(FallbackDriver::class);
+    expect($driver->getDrivers())->toHaveCount(2);
+});

--- a/tests/Integration/FallbackIntegrationTest.php
+++ b/tests/Integration/FallbackIntegrationTest.php
@@ -2,11 +2,13 @@
 
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Exceptions;
 use Spatie\LaravelPdf\Drivers\FallbackDriver;
 use Spatie\LaravelPdf\Exceptions\CouldNotGeneratePdf;
 use Spatie\LaravelPdf\Facades\Pdf;
 
 beforeEach(function () {
+    Exceptions::fake();
     forgetPdfDriverInstances();
 
     Config::set('laravel-pdf.fallback', [

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,7 +1,9 @@
 <?php
 
 use Spatie\Image\Image;
+use Spatie\LaravelPdf\Drivers\PdfDriver;
 use Spatie\LaravelPdf\PdfFactory;
+use Spatie\LaravelPdf\PdfOptions;
 use Spatie\LaravelPdf\Tests\TestCase;
 use Spatie\PdfToText\Pdf;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
@@ -116,4 +118,52 @@ function convertPdfToImage(string $pdfPath): string
     file_put_contents($imagePath, $imagick);
 
     return $imagePath;
+}
+
+function fakePdfDriver(string|Throwable $output): PdfDriver
+{
+    return new class($output) implements PdfDriver
+    {
+        public int $generateCalls = 0;
+
+        public int $saveCalls = 0;
+
+        public function __construct(public string|Throwable $output) {}
+
+        public function generatePdf(string $html, ?string $headerHtml, ?string $footerHtml, PdfOptions $options): string
+        {
+            $this->generateCalls++;
+
+            if ($this->output instanceof Throwable) {
+                throw $this->output;
+            }
+
+            return $this->output;
+        }
+
+        public function savePdf(string $html, ?string $headerHtml, ?string $footerHtml, PdfOptions $options, string $path): void
+        {
+            $this->saveCalls++;
+
+            if ($this->output instanceof Throwable) {
+                throw $this->output;
+            }
+
+            file_put_contents($path, $this->output);
+        }
+    };
+}
+
+function bindFakeDriver(string $name, PdfDriver $driver): void
+{
+    app()->instance("laravel-pdf.driver.{$name}", $driver);
+}
+
+function forgetPdfDriverInstances(): void
+{
+    foreach (['browsershot', 'cloudflare', 'dompdf', 'gotenberg', 'weasyprint', 'chrome'] as $name) {
+        app()->forgetInstance("laravel-pdf.driver.{$name}");
+    }
+
+    app()->forgetInstance(PdfDriver::class);
 }

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Env;
 use Illuminate\Support\Facades\Config;
 use Spatie\Browsershot\Browsershot;
 use Spatie\LaravelPdf\Drivers\BrowsershotDriver;
@@ -131,6 +132,38 @@ it('applies tagged pdf option to browsershot', function () {
     $browsershot = invade($driver)->buildBrowsershot('test', null, null, $options);
 
     expect(invade($browsershot)->taggedPdf)->toBeTrue();
+});
+
+it('splits LARAVEL_PDF_FALLBACK_DRIVERS env into the drivers array', function () {
+    Env::getRepository()->set('LARAVEL_PDF_FALLBACK_DRIVERS', 'dompdf,chrome,gotenberg');
+
+    try {
+        $config = require __DIR__.'/../../config/laravel-pdf.php';
+
+        expect(array_values($config['fallback']['drivers']))->toBe(['dompdf', 'chrome', 'gotenberg']);
+    } finally {
+        Env::getRepository()->clear('LARAVEL_PDF_FALLBACK_DRIVERS');
+    }
+});
+
+it('returns an empty drivers array when LARAVEL_PDF_FALLBACK_DRIVERS env is unset', function () {
+    Env::getRepository()->clear('LARAVEL_PDF_FALLBACK_DRIVERS');
+
+    $config = require __DIR__.'/../../config/laravel-pdf.php';
+
+    expect($config['fallback']['drivers'])->toBe([]);
+});
+
+it('splits a single LARAVEL_PDF_FALLBACK_DRIVERS driver', function () {
+    Env::getRepository()->set('LARAVEL_PDF_FALLBACK_DRIVERS', 'dompdf');
+
+    try {
+        $config = require __DIR__.'/../../config/laravel-pdf.php';
+
+        expect(array_values($config['fallback']['drivers']))->toBe(['dompdf']);
+    } finally {
+        Env::getRepository()->clear('LARAVEL_PDF_FALLBACK_DRIVERS');
+    }
 });
 
 function getBrowsershotOption(object $browsershot, string $key): mixed

--- a/tests/Unit/FallbackDriverTest.php
+++ b/tests/Unit/FallbackDriverTest.php
@@ -1,0 +1,302 @@
+<?php
+
+use Illuminate\Contracts\Cache\Repository as CacheRepositoryContract;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Support\Facades\Cache;
+use Spatie\LaravelPdf\Drivers\FallbackDriver;
+use Spatie\LaravelPdf\Exceptions\CouldNotGeneratePdf;
+use Spatie\LaravelPdf\PdfOptions;
+
+function nullExceptionHandler(): ExceptionHandler
+{
+    return new class implements ExceptionHandler
+    {
+        public array $reported = [];
+
+        public function report(Throwable $e)
+        {
+            $this->reported[] = $e;
+        }
+
+        public function shouldReport(Throwable $e)
+        {
+            return true;
+        }
+
+        public function render($request, Throwable $e)
+        {
+            return null;
+        }
+
+        public function renderForConsole($output, Throwable $e) {}
+    };
+}
+
+function makeFallback(
+    array $driversAndNames,
+    ExceptionHandler $handler,
+    array $onlyOn = [],
+    array $except = [],
+    ?CacheRepositoryContract $cache = null,
+    int $ttl = 0,
+    string $prefix = 'laravel_pdf_driver_health_',
+): FallbackDriver {
+    return new FallbackDriver(
+        drivers: $driversAndNames,
+        exceptionHandler: $handler,
+        onlyOnExceptions: $onlyOn,
+        exceptExceptions: $except,
+        cacheRepository: $cache,
+        healthCacheTtl: $ttl,
+        healthCacheKeyPrefix: $prefix,
+    );
+}
+
+it('uses the primary driver when it succeeds', function () {
+    $primary = fakePdfDriver('primary-output');
+    $fallback = fakePdfDriver('fallback-output');
+
+    $driver = makeFallback(
+        ['primary' => $primary, 'fallback' => $fallback],
+        nullExceptionHandler(),
+    );
+
+    $result = $driver->generatePdf('<h1>x</h1>', null, null, new PdfOptions);
+
+    expect($result)->toBe('primary-output');
+    expect($primary->generateCalls)->toBe(1);
+    expect($fallback->generateCalls)->toBe(0);
+});
+
+it('falls back to the next driver when the first throws', function () {
+    $primary = fakePdfDriver(new RuntimeException('boom'));
+    $fallback = fakePdfDriver('fallback-output');
+
+    $driver = makeFallback(
+        ['primary' => $primary, 'fallback' => $fallback],
+        nullExceptionHandler(),
+    );
+
+    $result = $driver->generatePdf('<h1>x</h1>', null, null, new PdfOptions);
+
+    expect($result)->toBe('fallback-output');
+    expect($primary->generateCalls)->toBe(1);
+    expect($fallback->generateCalls)->toBe(1);
+});
+
+it('falls back through multiple drivers until one succeeds', function () {
+    $a = fakePdfDriver(new RuntimeException('a-fail'));
+    $b = fakePdfDriver(new RuntimeException('b-fail'));
+    $c = fakePdfDriver('c-ok');
+
+    $driver = makeFallback(
+        ['a' => $a, 'b' => $b, 'c' => $c],
+        nullExceptionHandler(),
+    );
+
+    expect($driver->generatePdf('h', null, null, new PdfOptions))->toBe('c-ok');
+});
+
+it('throws CouldNotGeneratePdf carrying attempts when all drivers fail', function () {
+    $a = fakePdfDriver(new RuntimeException('a-fail'));
+    $b = fakePdfDriver(new RuntimeException('b-fail'));
+
+    $driver = makeFallback(
+        ['a' => $a, 'b' => $b],
+        nullExceptionHandler(),
+    );
+
+    try {
+        $driver->generatePdf('h', null, null, new PdfOptions);
+        $this->fail('Expected CouldNotGeneratePdf');
+    } catch (CouldNotGeneratePdf $e) {
+        expect($e->attemptedDrivers)->toBe(['a', 'b']);
+        expect($e->driverExceptions)->toHaveKeys(['a', 'b']);
+        expect($e->driverExceptions['b']->getMessage())->toBe('b-fail');
+        expect($e->getPrevious())->toBe($e->driverExceptions['b']);
+    }
+});
+
+it('only_on_exceptions: does not fall back when exception is not in allowlist', function () {
+    $a = fakePdfDriver(new RuntimeException('not allowed'));
+    $b = fakePdfDriver('b-ok');
+
+    $driver = makeFallback(
+        ['a' => $a, 'b' => $b],
+        nullExceptionHandler(),
+        onlyOn: [LogicException::class],
+    );
+
+    expect(fn () => $driver->generatePdf('h', null, null, new PdfOptions))
+        ->toThrow(RuntimeException::class, 'not allowed');
+
+    expect($b->generateCalls)->toBe(0);
+});
+
+it('only_on_exceptions: falls back when exception is in allowlist', function () {
+    $a = fakePdfDriver(new RuntimeException('allowed'));
+    $b = fakePdfDriver('b-ok');
+
+    $driver = makeFallback(
+        ['a' => $a, 'b' => $b],
+        nullExceptionHandler(),
+        onlyOn: [RuntimeException::class],
+    );
+
+    expect($driver->generatePdf('h', null, null, new PdfOptions))->toBe('b-ok');
+});
+
+it('except_exceptions: does not fall back when exception is in denylist', function () {
+    $a = fakePdfDriver(new LogicException('blocked'));
+    $b = fakePdfDriver('b-ok');
+
+    $driver = makeFallback(
+        ['a' => $a, 'b' => $b],
+        nullExceptionHandler(),
+        except: [LogicException::class],
+    );
+
+    expect(fn () => $driver->generatePdf('h', null, null, new PdfOptions))
+        ->toThrow(LogicException::class, 'blocked');
+});
+
+it('except_exceptions: falls back when exception is not in denylist', function () {
+    $a = fakePdfDriver(new RuntimeException('not blocked'));
+    $b = fakePdfDriver('b-ok');
+
+    $driver = makeFallback(
+        ['a' => $a, 'b' => $b],
+        nullExceptionHandler(),
+        except: [LogicException::class],
+    );
+
+    expect($driver->generatePdf('h', null, null, new PdfOptions))->toBe('b-ok');
+});
+
+it('only_on_exceptions takes precedence when both are configured', function () {
+    $a = fakePdfDriver(new RuntimeException('runtime'));
+    $b = fakePdfDriver('b-ok');
+
+    $driver = makeFallback(
+        ['a' => $a, 'b' => $b],
+        nullExceptionHandler(),
+        onlyOn: [RuntimeException::class],
+        except: [RuntimeException::class],
+    );
+
+    expect($driver->generatePdf('h', null, null, new PdfOptions))->toBe('b-ok');
+});
+
+it('reports each captured exception via the ExceptionHandler', function () {
+    $a = fakePdfDriver(new RuntimeException('a'));
+    $b = fakePdfDriver(new RuntimeException('b'));
+    $c = fakePdfDriver('ok');
+
+    $handler = nullExceptionHandler();
+
+    makeFallback(['a' => $a, 'b' => $b, 'c' => $c], $handler)
+        ->generatePdf('h', null, null, new PdfOptions);
+
+    expect($handler->reported)->toHaveCount(2);
+    expect($handler->reported[0]->getMessage())->toBe('a');
+    expect($handler->reported[1]->getMessage())->toBe('b');
+});
+
+it('savePdf falls back across drivers and writes to disk', function () {
+    $a = fakePdfDriver(new RuntimeException('a'));
+    $b = fakePdfDriver('saved-content');
+
+    $driver = makeFallback(['a' => $a, 'b' => $b], nullExceptionHandler());
+
+    $path = getTempPath('fallback-save-test.pdf');
+    $driver->savePdf('h', null, null, new PdfOptions, $path);
+
+    expect(file_get_contents($path))->toBe('saved-content');
+    expect($a->saveCalls)->toBe(1);
+    expect($b->saveCalls)->toBe(1);
+});
+
+it('skips a driver marked unhealthy in the cache', function () {
+    $a = fakePdfDriver(new RuntimeException('a'));
+    $b = fakePdfDriver('b-ok');
+
+    $cache = Cache::store('array');
+    $cache->put('laravel_pdf_driver_health_a', true, 600);
+
+    $driver = makeFallback(
+        ['a' => $a, 'b' => $b],
+        nullExceptionHandler(),
+        cache: $cache,
+        ttl: 600,
+    );
+
+    expect($driver->generatePdf('h', null, null, new PdfOptions))->toBe('b-ok');
+    expect($a->generateCalls)->toBe(0);
+});
+
+it('marks a driver unhealthy after a failure', function () {
+    $a = fakePdfDriver(new RuntimeException('a'));
+    $b = fakePdfDriver('b-ok');
+
+    $cache = Cache::store('array');
+    $cache->flush();
+
+    makeFallback(
+        ['a' => $a, 'b' => $b],
+        nullExceptionHandler(),
+        cache: $cache,
+        ttl: 600,
+    )->generatePdf('h', null, null, new PdfOptions);
+
+    expect($cache->has('laravel_pdf_driver_health_a'))->toBeTrue();
+    expect($cache->has('laravel_pdf_driver_health_b'))->toBeFalse();
+});
+
+it('uses the configured cache key prefix', function () {
+    $a = fakePdfDriver(new RuntimeException('a'));
+    $b = fakePdfDriver('b-ok');
+
+    $cache = Cache::store('array');
+    $cache->flush();
+
+    makeFallback(
+        ['a' => $a, 'b' => $b],
+        nullExceptionHandler(),
+        cache: $cache,
+        ttl: 600,
+        prefix: 'tenant1_pdf_',
+    )->generatePdf('h', null, null, new PdfOptions);
+
+    expect($cache->has('tenant1_pdf_a'))->toBeTrue();
+});
+
+it('does not write to cache when ttl is zero', function () {
+    $a = fakePdfDriver(new RuntimeException('a'));
+    $b = fakePdfDriver('b-ok');
+
+    $cache = Cache::store('array');
+    $cache->flush();
+
+    makeFallback(
+        ['a' => $a, 'b' => $b],
+        nullExceptionHandler(),
+        cache: $cache,
+        ttl: 0,
+    )->generatePdf('h', null, null, new PdfOptions);
+
+    expect($cache->has('laravel_pdf_driver_health_a'))->toBeFalse();
+});
+
+it('does not interact with cache when repository is null', function () {
+    $a = fakePdfDriver(new RuntimeException('a'));
+    $b = fakePdfDriver('b-ok');
+
+    $driver = makeFallback(
+        ['a' => $a, 'b' => $b],
+        nullExceptionHandler(),
+        cache: null,
+        ttl: 600,
+    );
+
+    expect($driver->generatePdf('h', null, null, new PdfOptions))->toBe('b-ok');
+});

--- a/tests/Unit/PdfHealthCommandTest.php
+++ b/tests/Unit/PdfHealthCommandTest.php
@@ -1,0 +1,101 @@
+<?php
+
+use Illuminate\Support\Facades\Config;
+
+beforeEach(fn () => forgetPdfDriverInstances());
+
+it('returns success when the primary driver is healthy and no fallback is configured', function () {
+    Config::set('laravel-pdf.driver', 'dompdf');
+    Config::set('laravel-pdf.fallback.drivers', []);
+
+    $dompdf = fakePdfDriver('pdf-content');
+    bindFakeDriver('dompdf', $dompdf);
+
+    $this->artisan('pdf:health')
+        ->expectsOutputToContain('All 1 driver(s) are healthy.')
+        ->assertSuccessful();
+
+    expect($dompdf->generateCalls)->toBe(1);
+});
+
+it('returns failure when the primary driver throws', function () {
+    Config::set('laravel-pdf.driver', 'cloudflare');
+    Config::set('laravel-pdf.fallback.drivers', []);
+
+    $cloudflare = fakePdfDriver(new RuntimeException('credentials missing'));
+    bindFakeDriver('cloudflare', $cloudflare);
+
+    $this->artisan('pdf:health')
+        ->expectsOutputToContain('1 of 1 driver(s) failed.')
+        ->assertFailed();
+
+    expect($cloudflare->generateCalls)->toBe(1);
+});
+
+it('checks the primary and every fallback driver', function () {
+    Config::set('laravel-pdf.driver', 'cloudflare');
+    Config::set('laravel-pdf.fallback.drivers', ['chrome', 'dompdf']);
+
+    $cloudflare = fakePdfDriver('a');
+    $chrome = fakePdfDriver('b');
+    $dompdf = fakePdfDriver('c');
+
+    bindFakeDriver('cloudflare', $cloudflare);
+    bindFakeDriver('chrome', $chrome);
+    bindFakeDriver('dompdf', $dompdf);
+
+    $this->artisan('pdf:health')
+        ->expectsOutputToContain('All 3 driver(s) are healthy.')
+        ->assertSuccessful();
+
+    expect($cloudflare->generateCalls)->toBe(1);
+    expect($chrome->generateCalls)->toBe(1);
+    expect($dompdf->generateCalls)->toBe(1);
+});
+
+it('reports a healthy primary alongside a failing fallback and exits with failure', function () {
+    Config::set('laravel-pdf.driver', 'cloudflare');
+    Config::set('laravel-pdf.fallback.drivers', ['dompdf']);
+
+    $cloudflare = fakePdfDriver('ok');
+    $dompdf = fakePdfDriver(new RuntimeException('dompdf-broken'));
+
+    bindFakeDriver('cloudflare', $cloudflare);
+    bindFakeDriver('dompdf', $dompdf);
+
+    $this->artisan('pdf:health')
+        ->expectsOutputToContain('1 of 2 driver(s) failed.')
+        ->assertFailed();
+
+    expect($cloudflare->generateCalls)->toBe(1);
+    expect($dompdf->generateCalls)->toBe(1);
+});
+
+it('deduplicates a driver appearing both as primary and as fallback', function () {
+    Config::set('laravel-pdf.driver', 'dompdf');
+    Config::set('laravel-pdf.fallback.drivers', ['dompdf', 'cloudflare']);
+
+    $dompdf = fakePdfDriver('a');
+    $cloudflare = fakePdfDriver('b');
+
+    bindFakeDriver('dompdf', $dompdf);
+    bindFakeDriver('cloudflare', $cloudflare);
+
+    $this->artisan('pdf:health')
+        ->expectsOutputToContain('All 2 driver(s) are healthy.')
+        ->assertSuccessful();
+
+    expect($dompdf->generateCalls)->toBe(1);
+    expect($cloudflare->generateCalls)->toBe(1);
+});
+
+it('shows the failure detail line for a broken driver', function () {
+    Config::set('laravel-pdf.driver', 'cloudflare');
+    Config::set('laravel-pdf.fallback.drivers', []);
+
+    bindFakeDriver('cloudflare', fakePdfDriver(new RuntimeException('upstream-down')));
+
+    $this->artisan('pdf:health')
+        ->expectsOutputToContain('upstream-down')
+        ->assertFailed();
+});


### PR DESCRIPTION
# 🛟 Add driver fallback chain + `pdf:health` command

> Make PDF generation resilient: if the primary driver fails, automatically try the next one in a configurable chain. Ships with an optional cache-backed circuit breaker and an Artisan command to verify every configured driver.

---

## 📌 Table of contents

- [Motivation](#-motivation)
- [What's new](#-whats-new)
- [How it works](#-how-it-works)
- [Usage](#-usage)
- [Configuration](#-configuration)
- [Health cache (circuit breaker)](#-health-cache-circuit-breaker)
- [`pdf:health` Artisan command](#-pdfhealth-artisan-command)
- [Error handling](#-error-handling)
- [Backward compatibility](#-backward-compatibility)
- [Tests](#-tests)
- [Checklist](#-checklist)

---

## 🎯 Motivation

PDF generation in production depends on moving parts that fail in different ways:

| Driver        | Typical failure mode                                         |
|---------------|--------------------------------------------------------------|
| `browsershot` | Chrome spawn error, `node` not found, OOM on big documents   |
| `chrome`      | Process crash, protocol timeout                              |
| `gotenberg`   | HTTP timeout, container down, upstream 5xx                   |
| `cloudflare`  | API 5xx, quota exceeded, credentials rotation                |
| `dompdf`      | Memory limit on complex HTML                                 |

Today the package binds a single driver. When that driver fails, the whole request fails — even when a cheap in-process fallback (e.g. `dompdf`) would have produced an acceptable document. Teams end up wrapping every `Pdf::html(...)` call with their own try/catch + retry logic, which is error-prone and hard to standardize across services.

This PR adds a first-class fallback chain inside the package, so resilience becomes a config flag instead of boilerplate.

---

## ✨ What's new

- 🔗 **`FallbackDriver`** — orders drivers in a chain, advances to the next on failure.
- 🎛️ **Fluent API** — `Pdf::html(...)->fallback('dompdf')` or `->fallback(['chrome', 'dompdf'])`.
- 📝 **Config-driven chain** — `laravel-pdf.fallback.drivers`, also accepts a comma-separated env variable.
- 🎯 **Exception filtering** — allowlist (`only_on_exceptions`) or denylist (`except_exceptions`) of throwable FQCNs that trigger the fallback.
- 🧠 **Health cache** — optional circuit breaker that skips drivers recently marked unhealthy until a TTL expires.
- 🩺 **`pdf:health` Artisan command** — pings each configured driver and reports healthy/failed with elapsed time.
- 📦 **Rich error context** — `CouldNotGeneratePdf` now carries `attemptedDrivers` and `driverExceptions` for observability.

---

## 🔧 How it works

```mermaid
flowchart TD
    A[Pdf::html&#40;...&#41;->save&#40;path&#41;] --> B{fallback chain configured?}
    B -- no --> C[primary driver runs] --> Z[✅ done]
    B -- yes --> D[FallbackDriver::run]
    D --> E{driver in health cache?}
    E -- yes --> F[skip]
    F --> G{more drivers?}
    E -- no --> H[try generatePdf / savePdf]
    H -- success --> Z
    H -- throws --> I{shouldFallback&#40;e&#41;?}
    I -- no --> J[🚫 re-throw as-is]
    I -- yes --> K[report via ExceptionHandler]
    K --> L[mark unhealthy in cache]
    L --> G
    G -- yes --> E
    G -- no --> M[❌ CouldNotGeneratePdf<br/>with attemptedDrivers + driverExceptions]
```

Short version:

1. `PdfBuilder::getDriver()` detects a configured fallback chain and wraps it in a `FallbackDriver`.
2. `FallbackDriver::run()` walks the chain in order, skipping drivers marked unhealthy in the cache.
3. If a driver throws, the decision to move on (or re-throw) is made by `shouldFallback()` using the allow/deny lists.
4. When none succeed, a single `CouldNotGeneratePdf` is thrown carrying every attempt and its exception.

---

## 🚀 Usage

### Fluent API (per-request)

```php
use Spatie\LaravelPdf\Facades\Pdf;

// single fallback
Pdf::html('<h1>Invoice</h1>')
    ->driver('cloudflare')
    ->fallback('dompdf')
    ->save('invoice.pdf');

// ordered chain
Pdf::html('<h1>Invoice</h1>')
    ->driver('gotenberg')
    ->fallback(['chrome', 'dompdf'])
    ->save('invoice.pdf');
```

The fluent chain always starts with the driver returned by `driver()` (or the package default), followed by the provided fallbacks.

### Global (every request, via config)

```php
// config/laravel-pdf.php
'driver' => 'gotenberg',

'fallback' => [
    'drivers' => ['chrome', 'dompdf'],
],
```

### Env-driven

```dotenv
LARAVEL_PDF_DRIVER=gotenberg
LARAVEL_PDF_FALLBACK_DRIVERS=chrome,dompdf
```

Empty env → no fallback (the package behaves exactly as before).

---

## ⚙️ Configuration

```php
'fallback' => [
    // Ordered list of fallback drivers. Set LARAVEL_PDF_FALLBACK_DRIVERS as a
    // comma-separated list, or override this array directly.
    'drivers' => array_filter(explode(',', env('LARAVEL_PDF_FALLBACK_DRIVERS', ''))),

    // Allowlist — if non-empty, ONLY these exceptions trigger the fallback.
    // Takes precedence over except_exceptions.
    'only_on_exceptions' => [],

    // Denylist — these exceptions are always re-thrown as-is, never trigger
    // a fallback. Useful for programmer errors you don't want to mask.
    'except_exceptions' => [],

    'health_cache' => [
        // Seconds a failing driver stays marked unhealthy. 0 disables the cache.
        'ttl' => env('LARAVEL_PDF_FALLBACK_HEALTH_TTL', 0),

        // Cache key prefix — override per-tenant if you share a cache store.
        'key_prefix' => 'laravel_pdf_driver_health_',

        // Cache store name. Null uses the app's default store.
        'store' => env('LARAVEL_PDF_FALLBACK_HEALTH_STORE'),
    ],
],
```

### When to use `only_on_exceptions` vs `except_exceptions`

| Situation                                              | Recommended                              |
|--------------------------------------------------------|------------------------------------------|
| "Fall back only on transient network/upstream errors"  | `only_on_exceptions` (narrow allowlist)  |
| "Fall back on anything, except view-rendering bugs"    | `except_exceptions` (narrow denylist)    |
| "Fall back on anything"                                | leave both empty                         |

The allowlist wins when both are set, so you never get silent drift if both configs grow.

---

## 🧠 Health cache (circuit breaker)

When `health_cache.ttl > 0`, every failure marks the driver as unhealthy in the cache for `ttl` seconds. Subsequent requests **skip** that driver without attempting it — avoiding the "wait 10s for Chrome to fail again on every request" pathology.

```mermaid
sequenceDiagram
    autonumber
    participant App
    participant Fallback as FallbackDriver
    participant Cache
    participant A as gotenberg
    participant B as dompdf

    App->>Fallback: generatePdf(...)
    Fallback->>Cache: has(laravel_pdf_driver_health_gotenberg)?
    Cache-->>Fallback: false
    Fallback->>A: generatePdf(...)
    A--xFallback: ConnectException
    Fallback->>Cache: put(..._gotenberg, true, 600)
    Fallback->>B: generatePdf(...)
    B-->>Fallback: PDF bytes
    Fallback-->>App: PDF bytes

    Note over App,B: Next request, within 600s

    App->>Fallback: generatePdf(...)
    Fallback->>Cache: has(..._gotenberg)?
    Cache-->>Fallback: true (skip)
    Fallback->>B: generatePdf(...)
    B-->>Fallback: PDF bytes
    Fallback-->>App: PDF bytes
```

Disabled by default (`ttl: 0`) — opt in when you want the circuit-breaker semantics.

---

## 🩺 `pdf:health` Artisan command

```bash
$ php artisan pdf:health

  INFO  Checking PDF driver health.

  gotenberg (primary) ................................... healthy 362ms
  dompdf (fallback) ..................................... healthy  18ms

  All 2 driver(s) are healthy.
```

Exits `0` if every driver generates a tiny sample PDF successfully, `1` otherwise. Integrate with your orchestrator's readiness probe, a CI job, or a periodic cron to catch misconfigurations early. Unknown drivers (typos in `.env`) are reported immediately with a clear message:

```
  cloudfare (fallback) ...... failed 0ms — Unknown PDF driver [cloudfare].
```

---

## 🧯 Error handling

When the entire chain fails, a single `CouldNotGeneratePdf` is thrown carrying the full post-mortem:

```php
try {
    Pdf::html($html)->save($path);
} catch (CouldNotGeneratePdf $e) {
    $e->attemptedDrivers;   // ['gotenberg', 'chrome', 'dompdf']
    $e->driverExceptions;   // ['gotenberg' => ConnectException, 'chrome' => ProcessFailedException, ...]
    $e->getPrevious();      // the last attempt's exception
}
```

Two distinct factory methods:

- `CouldNotGeneratePdf::allFallbackFailed($names, $exceptions)` — at least one driver was attempted and all failed.
- `CouldNotGeneratePdf::allDriversUnhealthy($names)` — every driver was skipped because the health cache marked them as open.

This separation lets observability tooling and runbooks tell "circuit open" apart from "everything actually tried and exploded" — two incidents with very different remediations.

---

## 🔁 Backward compatibility

✅ **Fully backward-compatible**. With no fallback configured:

- `fallback.drivers` defaults to `[]` → no chain is built → `PdfServiceProvider` resolves the single primary driver exactly as before.
- `PdfBuilder::getDriver()` only wraps in a `FallbackDriver` when a chain is provided.
- No existing method signatures or public properties changed.
- Published config files keep working; re-publish to get the new `fallback` section with documentation.

---

## 🧪 Tests

**36 new tests / ~70 new assertions**, plus shared fake-driver helpers consolidated in `tests/Pest.php`:

| Suite                                         | Tests | Focus                                                                      |
|-----------------------------------------------|------:|----------------------------------------------------------------------------|
| `tests/Unit/FallbackDriverTest.php`           |    16 | Chain ordering, allowlist/denylist semantics, health cache, save() path, exception reporting |
| `tests/Unit/PdfHealthCommandTest.php`         |     6 | Success/failure exit codes, dedup of primary + fallback, unknown-driver reporting |
| `tests/Integration/FallbackIntegrationTest.php`|   11 | Full pipeline through `PdfBuilder`/`PdfServiceProvider`, fluent API vs config precedence, cache persistence |
| `tests/Unit/ConfigurationTest.php` (additions)|     3 | `LARAVEL_PDF_FALLBACK_DRIVERS` env split / empty / single value           |

Test doubles avoid external dependencies: unit tests use in-process fake `PdfDriver` implementations, integration tests bind fakes into the container so the real `PdfBuilder` → `PdfServiceProvider::buildFallbackDriver()` → `FallbackDriver::run()` pipeline is exercised end-to-end without requiring Chrome, Gotenberg, or Cloudflare credentials.

Integration tests call `Exceptions::fake()` in `beforeEach` to prevent the real `ExceptionHandler` from pulling the full logging stack into the test path — a pragmatic isolation that keeps CI deterministic across the `prefer-lowest` matrix.

---

## ✅ Checklist

- [x] Fully backward-compatible: no fallback configured → behavior identical to `main`.
- [x] New public surface (`Pdf::fallback()`, config keys, `pdf:health`) is documented inline in the config file and README-adjacent.
- [x] All new code paths covered by unit + integration tests.
- [x] `CouldNotGeneratePdf` surfaces enough context (`attemptedDrivers`, `driverExceptions`) for log aggregators and APM tools.
- [x] Health cache is **opt-in** (`ttl: 0` by default) — existing users see no behavior change.
- [x] No new hard dependencies; `Illuminate\Contracts\Cache\Repository` is already transitively available.
- [x] Follows the package's existing patterns (service-provider binding, config-driven drivers, Pest tests).

---

Happy to split this into smaller PRs if the maintainers prefer — e.g. `FallbackDriver` core first, then the health cache, then the `pdf:health` command. The commit history is already structured around those boundaries (`feat(fallback): ...`).
