### PR TITLE
feat(chrome): add operation timeout configuration for PDF generation

### DIFF
--- a/config/laravel-pdf.php
+++ b/config/laravel-pdf.php
@@ -123,6 +123,8 @@ return [
 
         'timeout' => env('LARAVEL_PDF_CHROME_TIMEOUT', 30000),
 
+        'operation_timeout' => env('LARAVEL_PDF_CHROME_OPERATION_TIMEOUT', 5000),
+
         'user_data_dir' => env('LARAVEL_PDF_CHROME_USER_DATA_DIR'),
 
         'custom_flags' => [],

--- a/docs/drivers/configuration.md
+++ b/docs/drivers/configuration.md
@@ -64,6 +64,7 @@ Configure the Chrome driver options:
     'no_sandbox' => env('LARAVEL_PDF_CHROME_NO_SANDBOX', false),
     'startup_timeout' => env('LARAVEL_PDF_CHROME_STARTUP_TIMEOUT', 30),
     'timeout' => env('LARAVEL_PDF_CHROME_TIMEOUT', 30000),
+    'operation_timeout' => env('LARAVEL_PDF_CHROME_OPERATION_TIMEOUT', 5000),
     'user_data_dir' => env('LARAVEL_PDF_CHROME_USER_DATA_DIR'),
     'custom_flags' => [],
     'env_variables' => [],
@@ -74,6 +75,7 @@ Configure the Chrome driver options:
 - **no_sandbox**: Disables Chrome's sandbox. This is sometimes needed in Docker or restricted server environments.
 - **startup_timeout**: Maximum time in seconds to wait for Chrome to start.
 - **timeout**: Maximum time in milliseconds to wait while setting the page HTML.
+- **operation_timeout**: Maximum time in milliseconds to wait for Chrome PDF operations like binary output and file saves.
 - **user_data_dir**: Custom Chrome profile directory.
 - **custom_flags**: Additional Chrome command-line flags.
 - **env_variables**: Environment variables passed to the Chrome process.
@@ -144,6 +146,7 @@ LARAVEL_PDF_CHROME_BINARY=/usr/bin/google-chrome-stable
 LARAVEL_PDF_CHROME_NO_SANDBOX=false
 LARAVEL_PDF_CHROME_STARTUP_TIMEOUT=30
 LARAVEL_PDF_CHROME_TIMEOUT=30000
+LARAVEL_PDF_CHROME_OPERATION_TIMEOUT=5000
 LARAVEL_PDF_CHROME_USER_DATA_DIR=/tmp/chrome-profile
 
 # Gotenberg settings

--- a/docs/drivers/using-the-chrome-driver.md
+++ b/docs/drivers/using-the-chrome-driver.md
@@ -62,6 +62,7 @@ The Chrome driver accepts these configuration options in `config/laravel-pdf.php
     'no_sandbox' => env('LARAVEL_PDF_CHROME_NO_SANDBOX', false),
     'startup_timeout' => env('LARAVEL_PDF_CHROME_STARTUP_TIMEOUT', 30),
     'timeout' => env('LARAVEL_PDF_CHROME_TIMEOUT', 30000),
+    'operation_timeout' => env('LARAVEL_PDF_CHROME_OPERATION_TIMEOUT', 5000),
     'user_data_dir' => env('LARAVEL_PDF_CHROME_USER_DATA_DIR'),
     'custom_flags' => [],
     'env_variables' => [],
@@ -72,6 +73,7 @@ The Chrome driver accepts these configuration options in `config/laravel-pdf.php
 - **no_sandbox**: Disables Chrome's sandbox. This is sometimes needed in Docker or restricted server environments.
 - **startup_timeout**: Maximum time in seconds to wait for Chrome to start.
 - **timeout**: Maximum time in milliseconds to wait when setting the page HTML.
+- **operation_timeout**: Maximum time in milliseconds to wait for Chrome PDF operations like binary output and file saves.
 - **user_data_dir**: Custom Chrome profile directory.
 - **custom_flags**: Additional Chrome command-line flags.
 - **env_variables**: Environment variables passed to the Chrome process.

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -163,6 +163,7 @@ return [
         'no_sandbox' => env('LARAVEL_PDF_CHROME_NO_SANDBOX', false),
         'startup_timeout' => env('LARAVEL_PDF_CHROME_STARTUP_TIMEOUT', 30),
         'timeout' => env('LARAVEL_PDF_CHROME_TIMEOUT', 30000),
+        'operation_timeout' => env('LARAVEL_PDF_CHROME_OPERATION_TIMEOUT', 5000),
         'user_data_dir' => env('LARAVEL_PDF_CHROME_USER_DATA_DIR'),
         'custom_flags' => [],
         'env_variables' => [],

--- a/src/Drivers/ChromeDriver.php
+++ b/src/Drivers/ChromeDriver.php
@@ -59,7 +59,7 @@ class ChromeDriver implements PdfDriver
             $pdfOptions = $this->buildPdfOptions($headerHtml, $footerHtml, $options);
             $pdf = $page->pdf($pdfOptions);
 
-            return $pdf->getRawBinary();
+            return $pdf->getRawBinary($this->config['operation_timeout'] ?? null);
         } finally {
             $browser->close();
         }
@@ -74,7 +74,9 @@ class ChromeDriver implements PdfDriver
             $page->setHtml($html, $this->config['timeout'] ?? 30000);
 
             $pdfOptions = $this->buildPdfOptions($headerHtml, $footerHtml, $options);
-            $page->pdf($pdfOptions)->saveToFile($path);
+            $pdf = $page->pdf($pdfOptions);
+
+            $pdf->saveToFile($path, $this->config['operation_timeout'] ?? 5000);
         } finally {
             $browser->close();
         }


### PR DESCRIPTION
Add operation timeout configuration.

When generating large PDFs file it will occur `HeadlessChromium\\Exception\\OperationTimedOut` exception due to the default 5 second timeout. This change add the operation timeout config option to override the default timeout.