### PR TITLE
Update Cloudflare Driver Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
     
 </div>
 
-This package provides a simple way to create PDFs in Laravel apps. It supports multiple drivers: [Browsershot](https://spatie.be/docs/browsershot) (Chromium), [Gotenberg](https://gotenberg.dev) (Docker-based), [Cloudflare Browser Rendering](https://developers.cloudflare.com/browser-rendering/), [WeasyPrint](https://doc.courtbouillon.org/weasyprint/stable/) (Python-based), [DOMPDF](https://github.com/dompdf/dompdf) (pure PHP), and [chrome-php/chrome](https://github.com/chrome-php/chrome) (Chromium). You can use modern CSS features like grid and flexbox with the Chromium-based drivers, use WeasyPrint for excellent CSS Paged Media support, or choose DOMPDF for a zero-dependency setup.
+This package provides a simple way to create PDFs in Laravel apps. It supports multiple drivers: [Browsershot](https://spatie.be/docs/browsershot) (Chromium), [Gotenberg](https://gotenberg.dev) (Docker-based), [Cloudflare Browser Run](https://developers.cloudflare.com/browser-run/), [WeasyPrint](https://doc.courtbouillon.org/weasyprint/stable/) (Python-based), [DOMPDF](https://github.com/dompdf/dompdf) (pure PHP), and [chrome-php/chrome](https://github.com/chrome-php/chrome) (Chromium). You can use modern CSS features like grid and flexbox with the Chromium-based drivers, use WeasyPrint for excellent CSS Paged Media support, or choose DOMPDF for a zero-dependency setup.
 
 Here's a quick example:
 

--- a/docs/drivers/using-the-cloudflare-driver.md
+++ b/docs/drivers/using-the-cloudflare-driver.md
@@ -68,4 +68,4 @@ The free Cloudflare Workers plan is limited to 6 REST API requests per minute an
 
 - The Cloudflare driver only supports PDF output. Saving as PNG (screenshots) is not supported.
 - The `withBrowsershot()` and `onLambda()` methods have no effect when using the Cloudflare driver.
-- JavaScript execution depends on Cloudflare's Browser Rendering API behavior — complex scripts may behave differently than in a local Chromium instance.
+- JavaScript execution depends on Cloudflare's Browser Run API behavior — complex scripts may behave differently than in a local Chromium instance.

--- a/docs/drivers/using-the-cloudflare-driver.md
+++ b/docs/drivers/using-the-cloudflare-driver.md
@@ -3,7 +3,7 @@ title: Using the Cloudflare driver
 weight: 3
 ---
 
-The Cloudflare driver uses [Cloudflare's Browser Rendering API](https://developers.cloudflare.com/browser-rendering/) to generate PDFs. Unlike the Browsershot driver, it does not require Node.js or a Chrome binary on your server. Instead, it makes a simple HTTP call to Cloudflare's API, which renders your HTML and returns a PDF.
+The Cloudflare driver uses [Cloudflare's Browser Run API](https://developers.cloudflare.com/browser-run/) to generate PDFs. Unlike the Browsershot driver, it does not require Node.js or a Chrome binary on your server. Instead, it makes a simple HTTP call to Cloudflare's API, which renders your HTML and returns a PDF.
 
 This approach was inspired by this tweet by [Dries Vints](https://x.com/driesvints/status/2016131972477632850).
 
@@ -11,8 +11,7 @@ This approach was inspired by this tweet by [Dries Vints](https://x.com/driesvin
 
 1. Make sure you have a [Cloudflare account](https://dash.cloudflare.com/sign-up)
 2. In the Cloudflare dashboard, go to **Manage account > Account API tokens** in the sidebar
-3. Click **Create Token** and create a token with the **Account.Browser Rendering** permission
-4. Your Account ID can be found in the address bar of the Cloudflare dashboard URL
+3. Click **Create Token** and create a token with the **Account.Browser Run** permission (both read and edit/write)
 
 ![Cloudflare API tokens page](/docs/laravel-pdf/v2/images/cloudflare-api-tokens.jpg)
 
@@ -63,7 +62,7 @@ Make sure you have the Cloudflare credentials configured in your `config/laravel
 
 ## Limits
 
-The free Cloudflare Workers plan is limited to 6 REST API requests per minute and 10 minutes of Browser Rendering usage per day. The paid Workers plan offers significantly higher limits. Check the [Cloudflare Browser Rendering limits page](https://developers.cloudflare.com/browser-rendering/platform/limits/) for the latest details.
+The free Cloudflare Workers plan is limited to 6 REST API requests per minute and 10 minutes of Browser Rendering usage per day. The paid Workers plan offers significantly higher limits. Check the [Cloudflare Browser Run limits page](https://developers.cloudflare.com/browser-run/limits/) for the latest details.
 
 ## Limitations
 

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -25,15 +25,14 @@ You'll also need to install the required dependencies for Browsershot to work. Y
 
 ### Cloudflare driver
 
-The Cloudflare driver uses [Cloudflare's Browser Rendering API](https://developers.cloudflare.com/browser-rendering/) to generate PDFs. It does not require Node.js or a Chrome binary, making it a great choice for cloud-hosted Laravel apps.
+The Cloudflare driver uses [Cloudflare's Browser Run API](https://developers.cloudflare.com/browser-run/) to generate PDFs. It does not require Node.js or a Chrome binary, making it a great choice for cloud-hosted Laravel apps.
 
 To get started with Cloudflare:
 
 1. Make sure you have a [Cloudflare account](https://dash.cloudflare.com/sign-up)
 2. In the Cloudflare dashboard, go to **Manage account > Account API tokens** in the sidebar
-3. Click **Create Token** and create a token with the **Account.Browser Rendering** permission
-4. Your Account ID can be found in the address bar of the Cloudflare dashboard URL
-5. Add the following to your `.env` file:
+3. Click **Create Token** and create a token with the **Account.Browser Run** permission (both read and edit/write)
+4. Add the following to your `.env` file:
 
 ```env
 LARAVEL_PDF_DRIVER=cloudflare

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -7,7 +7,7 @@ This package provides a simple way to create PDFs in Laravel apps. It uses a dri
 
 - **Browsershot** (default): Uses [Chromium](https://www.chromium.org/chromium-projects/) via [Browsershot](https://spatie.be/docs/browsershot) to generate PDFs from HTML. Requires Node.js and a Chrome/Chromium binary.
 - **Gotenberg**: Uses [Gotenberg](https://gotenberg.dev), an open-source Docker-based API with headless Chromium. Great for containerized and microservice environments.
-- **Cloudflare**: Uses [Cloudflare's Browser Rendering API](https://developers.cloudflare.com/browser-rendering/) to generate PDFs with a simple HTTP call. No Node.js or Chrome binary needed. This driver was inspired by [a suggestion from Dries Vints](https://x.com/driesvints/status/2016131972477632850).
+- **Cloudflare**: Uses [Cloudflare's Browser Run API](https://developers.cloudflare.com/browser-run/) to generate PDFs with a simple HTTP call. No Node.js or Chrome binary needed. This driver was inspired by [a suggestion from Dries Vints](https://x.com/driesvints/status/2016131972477632850).
 - **WeasyPrint**: Uses [WeasyPrint](https://doc.courtbouillon.org/weasyprint/stable/) via [pontedilana/php-weasyprint](https://github.com/pontedilana/php-weasyprint) for Python-based PDF generation with excellent CSS Paged Media support. Requires the WeasyPrint binary.
 - **DOMPDF**: Uses [dompdf/dompdf](https://github.com/dompdf/dompdf) for pure PHP PDF generation. No external binaries, no Node.js, no Docker — works everywhere PHP runs.
 - **Chrome**: Uses [chrome-php/chrome](https://github.com/chrome-php/chrome) to talk directly to a local Chrome or Chromium binary from PHP. Requires a Chrome/Chromium 65+ executable.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -34,9 +34,9 @@ The WeasyPrint driver uses [WeasyPrint](https://doc.courtbouillon.org/weasyprint
 
 ## Cloudflare driver
 
-The Cloudflare driver uses [Cloudflare's Browser Rendering API](https://developers.cloudflare.com/browser-rendering/). This driver does not require Node.js or a Chrome binary on your server. You will need:
+The Cloudflare driver uses [Cloudflare's Browser Run API](https://developers.cloudflare.com/browser-run/). This driver does not require Node.js or a Chrome binary on your server. You will need:
 
-- A [Cloudflare account](https://dash.cloudflare.com/sign-up) with the Browser Rendering API enabled
+- A [Cloudflare account](https://dash.cloudflare.com/sign-up) with the Browser Run API enabled
 - A Cloudflare API token with the appropriate permissions
 - Your Cloudflare account ID
 


### PR DESCRIPTION
Cloudflare [announced changes to the Cloudflare Browser Rendering API](https://developers.cloudflare.com/changelog/post/2026-04-15-br-rename/) on April 15th 2026.

- The product has been renamed to Cloudflare Browser Run
- The API key permissions have been renamed accordingly 
- The API key generation workflow now also gives you your account ID, so you don't have to get it from the URI

This pull request updates the documentation to reflect these changes.  

I have also highlighted that the API key needs write permissions also, having encountered error 10000 (authentication failure) when I tried to upgrade without doing the write permission also.