### PR TITLE
Support setting and asserting Browsershot config with Pdf::fake()

### DIFF
--- a/src/Facades/Pdf.php
+++ b/src/Facades/Pdf.php
@@ -18,10 +18,16 @@ class Pdf extends Facade
         return PdfFactory::class;
     }
 
-    public static function fake()
+    public static function fake(): FakePdfBuilder
     {
         $fake = new FakePdfBuilder;
 
+        if ($callback = PdfFactory::defaultBuilder()->getCustomizeBrowsershotCallback()) {
+            $fake->withBrowsershot($callback);
+        }
+
         static::swap($fake);
+
+        return $fake;
     }
 }

--- a/src/FakePdfBuilder.php
+++ b/src/FakePdfBuilder.php
@@ -6,6 +6,7 @@ use Closure;
 use Illuminate\Http\Response;
 use Illuminate\Support\Arr;
 use PHPUnit\Framework\Assert;
+use Spatie\Browsershot\Browsershot;
 
 class FakePdfBuilder extends PdfBuilder
 {
@@ -131,6 +132,32 @@ class FakePdfBuilder extends PdfBuilder
                 Assert::assertStringNotContainsString((string) $string, $savedPdf['pdf']->html);
             }
         }
+    }
+
+    public function assertBrowsershot(Closure $expectations): void
+    {
+        $recordedPdfs = [
+            ...array_column($this->savedPdfs, 'pdf'),
+            ...$this->respondedWithPdf,
+        ];
+
+        Assert::assertNotEmpty($recordedPdfs, 'No PDF was generated');
+
+        foreach ($recordedPdfs as $pdf) {
+            $browsershot = Browsershot::html($pdf->html);
+
+            if ($callback = $pdf->getCustomizeBrowsershotCallback()) {
+                $callback($browsershot);
+            }
+
+            if ($expectations($browsershot) === true) {
+                $this->markAssertionPassed();
+
+                return;
+            }
+        }
+
+        Assert::fail('Did not configure Browsershot in the expected way');
     }
 
     public function assertRespondedWithPdf(Closure $expectations): void

--- a/src/PdfBuilder.php
+++ b/src/PdfBuilder.php
@@ -327,6 +327,11 @@ class PdfBuilder implements Attachable, Responsable
         return $this;
     }
 
+    public function getCustomizeBrowsershotCallback(): ?Closure
+    {
+        return $this->customizeBrowsershot;
+    }
+
     public function onLambda(): self
     {
         $this->onLambda = true;

--- a/src/PdfFactory.php
+++ b/src/PdfFactory.php
@@ -8,9 +8,7 @@ class PdfFactory
 
     public function __construct()
     {
-        if (self::$defaultPdfBuilder === null) {
-            self::$defaultPdfBuilder = new PdfBuilder;
-        }
+        self::defaultBuilder();
     }
 
     public function __call($method, $parameters): PdfBuilder
@@ -27,6 +25,15 @@ class PdfFactory
         self::$defaultPdfBuilder = $pdfBuilder;
 
         return $pdfBuilder;
+    }
+
+    public static function defaultBuilder(): PdfBuilder
+    {
+        if (self::$defaultPdfBuilder === null) {
+            self::$defaultPdfBuilder = new PdfBuilder;
+        }
+
+        return self::$defaultPdfBuilder;
     }
 
     public static function resetDefaultBuilder(): void

--- a/tests/Unit/FakePdfBrowsershotTest.php
+++ b/tests/Unit/FakePdfBrowsershotTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Spatie\Browsershot\Browsershot;
+use Spatie\LaravelPdf\Facades\Pdf;
+
+use function Spatie\LaravelPdf\Support\pdf;
+
+function browsershotUsesRemoteInstance(Browsershot $browsershot, string $url): bool
+{
+    return (invade($browsershot)->additionalOptions['remoteInstanceUrl'] ?? null) === $url;
+}
+
+it('can assert the browsershot configuration of a saved fake pdf', function () {
+    Pdf::fake();
+
+    Pdf::view('test')
+        ->withBrowsershot(function (Browsershot $browsershot) {
+            $browsershot->setRemoteInstance('127.0.0.1', 9222);
+        })
+        ->save('remote.pdf');
+
+    Pdf::assertBrowsershot(
+        fn (Browsershot $browsershot) => browsershotUsesRemoteInstance($browsershot, 'http://127.0.0.1:9222'),
+    );
+});
+
+it('can assert the browsershot configuration of a fake pdf response', function () {
+    Pdf::fake();
+
+    Route::get('pdf', function () {
+        return pdf('test')
+            ->withBrowsershot(function (Browsershot $browsershot) {
+                $browsershot->setRemoteInstance('127.0.0.1', 9222);
+            })
+            ->inline();
+    });
+
+    $this->get('pdf')->assertSuccessful();
+
+    Pdf::assertBrowsershot(
+        fn (Browsershot $browsershot) => browsershotUsesRemoteInstance($browsershot, 'http://127.0.0.1:9222'),
+    );
+});
+
+it('fails when no fake pdf matches the browsershot expectations', function () {
+    Pdf::fake();
+
+    Pdf::view('test')->save('plain.pdf');
+
+    Pdf::assertBrowsershot(
+        fn (Browsershot $browsershot) => browsershotUsesRemoteInstance($browsershot, 'http://127.0.0.1:9222'),
+    );
+})->fails();
+
+it('uses the browsershot configuration from the default builder when faking', function () {
+    Pdf::default()->withBrowsershot(function (Browsershot $browsershot) {
+        $browsershot->setRemoteInstance('127.0.0.1', 9222);
+    });
+
+    Pdf::fake();
+
+    Pdf::view('test')->save('remote.pdf');
+
+    Pdf::assertBrowsershot(
+        fn (Browsershot $browsershot) => browsershotUsesRemoteInstance($browsershot, 'http://127.0.0.1:9222'),
+    );
+});


### PR DESCRIPTION
Fixes #338

When using `Pdf::fake()`, Browsershot customizations were unusable: a `withBrowsershot()` closure configured on the default builder (for example in a service provider via `Pdf::default()->withBrowsershot(...)`) was dropped when faking, and there was no way to assert how Browsershot was configured.

## Changes

- `Pdf::fake()` now carries over the `withBrowsershot()` closure configured on the default builder, and returns the `FakePdfBuilder`.
- Added `Pdf::assertBrowsershot(Closure $expectations)`. It applies the captured `withBrowsershot()` closure to a `Browsershot` instance and hands it to the expectation closure, so you can assert configuration such as `setRemoteInstance()`.
- Added `PdfBuilder::getCustomizeBrowsershotCallback()` and `PdfFactory::defaultBuilder()` to support the above.
- Added tests covering saved PDFs, response PDFs, and the default-builder carry-over.

The assertion reflects the configuration applied by the `withBrowsershot()` closure itself (it does not re-apply builder-level options like format/margins, which are already assertable through `assertSaved`/`assertRespondedWithPdf`).