### PR TITLE
Feature/pdf password protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ Pdf::view('pdfs.invoice', ['invoice' => $invoice])
 
 This will render the Blade view `pdfs.invoice` with the given data and save it as a PDF file.
 
+You may also require a password before the PDF can be opened:
+
+```php
+Pdf::view('pdfs.invoice', ['invoice' => $invoice])
+    ->password('secret123')
+    ->save('invoice.pdf')
+```
+
 You can also return the PDF as a response from your controller:
 
 ```php

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": "^8.2",
         "illuminate/contracts": "^11.0|^12.0|^13.0",
+        "setasign/fpdi-protection": "^2.1",
         "spatie/laravel-package-tools": "^1.16.1",
         "spatie/temporary-directory": "^2.2.1"
     },

--- a/docs/basic-usage/formatting-pdfs.md
+++ b/docs/basic-usage/formatting-pdfs.md
@@ -195,6 +195,20 @@ Pdf::view('pdf.invoice', ['invoice' => $invoice])
 
 > Tagged PDFs are supported by the Browsershot and Cloudflare drivers. The DOMPDF driver does not support this option.
 
+## Password protection
+
+You can require a password before the PDF can be opened using the `password` method.
+
+```php
+use Spatie\LaravelPdf\Facades\Pdf;
+
+Pdf::view('pdf.invoice', ['invoice' => $invoice])
+    ->password('secret123')
+    ->save('/some/directory/invoice.pdf');
+```
+
+Password protection is applied after the driver has generated the PDF, so it works with all drivers.
+
 ## PDF metadata
 
 You can set PDF document metadata such as title, author, subject, and keywords using the `meta` method. This metadata is displayed in PDF viewers — for example, the title is shown in the browser tab when viewing a PDF inline.

--- a/src/Jobs/GeneratePdfJob.php
+++ b/src/Jobs/GeneratePdfJob.php
@@ -14,6 +14,8 @@ use Spatie\LaravelPdf\Drivers\PdfDriver;
 use Spatie\LaravelPdf\PdfMetadata;
 use Spatie\LaravelPdf\PdfMetadataWriter;
 use Spatie\LaravelPdf\PdfOptions;
+use Spatie\LaravelPdf\PostProcessing\PasswordProtectionPostProcessor;
+use Spatie\LaravelPdf\PostProcessing\PdfPostProcessor;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
 use Throwable;
 
@@ -62,7 +64,7 @@ class GeneratePdfJob implements ShouldQueue
 
         if ($this->diskName) {
             $this->saveOnDisk($driver);
-        } elseif ($this->hasMetadata()) {
+        } elseif ($this->hasPostProcessors()) {
             $content = $driver->generatePdf(
                 $this->html,
                 $this->headerHtml,
@@ -70,7 +72,7 @@ class GeneratePdfJob implements ShouldQueue
                 $this->options,
             );
 
-            file_put_contents($this->path, $this->applyMetadata($content));
+            file_put_contents($this->path, $this->applyPostProcessors($content));
         } else {
             $driver->savePdf(
                 $this->html,
@@ -120,22 +122,42 @@ class GeneratePdfJob implements ShouldQueue
 
         $temporaryDirectory->delete();
 
-        $content = $this->applyMetadata($content);
+        $content = $this->applyPostProcessors($content);
 
         Storage::disk($this->diskName)->put($this->path, $content, $this->visibility);
     }
 
-    protected function applyMetadata(string $pdfContent): string
+    protected function applyPostProcessors(string $pdfContent): string
     {
-        if (! $this->hasMetadata()) {
-            return $pdfContent;
+        if ($this->hasMetadata()) {
+            $pdfContent = PdfMetadataWriter::write($pdfContent, $this->metadata);
         }
 
-        return PdfMetadataWriter::write($pdfContent, $this->metadata);
+        foreach ($this->postProcessors() as $postProcessor) {
+            $pdfContent = $postProcessor->process($pdfContent);
+        }
+
+        return $pdfContent;
     }
 
     protected function hasMetadata(): bool
     {
         return $this->metadata !== null && ! $this->metadata->isEmpty();
+    }
+
+    protected function hasPostProcessors(): bool
+    {
+        return $this->hasMetadata()
+            || $this->options->password !== null;
+    }
+
+    /**
+     * @return array<int, PdfPostProcessor>
+     */
+    protected function postProcessors(): array
+    {
+        return [
+            ...($this->options->password !== null ? [new PasswordProtectionPostProcessor($this->options->password)] : []),
+        ];
     }
 }

--- a/src/PdfBuilder.php
+++ b/src/PdfBuilder.php
@@ -19,6 +19,8 @@ use Spatie\LaravelPdf\Enums\Orientation;
 use Spatie\LaravelPdf\Enums\Unit;
 use Spatie\LaravelPdf\Exceptions\CouldNotGeneratePdf;
 use Spatie\LaravelPdf\Jobs\GeneratePdfJob;
+use Spatie\LaravelPdf\PostProcessing\PasswordProtectionPostProcessor;
+use Spatie\LaravelPdf\PostProcessing\PdfPostProcessor;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
 
 class PdfBuilder implements Attachable, Responsable
@@ -62,6 +64,8 @@ class PdfBuilder implements Attachable, Responsable
     public bool $tagged = false;
 
     public ?PdfMetadata $metadata = null;
+
+    public ?string $password = null;
 
     protected string $visibility = 'private';
 
@@ -295,6 +299,13 @@ class PdfBuilder implements Attachable, Responsable
         return $this;
     }
 
+    public function password(string $password): self
+    {
+        $this->password = $password;
+
+        return $this;
+    }
+
     public function meta(
         ?string $title = null,
         ?string $author = null,
@@ -345,7 +356,7 @@ class PdfBuilder implements Attachable, Responsable
             return $this->saveOnDisk($this->diskName, $path);
         }
 
-        if ($this->hasMetadata()) {
+        if ($this->hasPostProcessors()) {
             file_put_contents($path, $this->generatePdfContent());
         } else {
             $this->getDriver()->savePdf(
@@ -421,7 +432,7 @@ class PdfBuilder implements Attachable, Responsable
 
         $temporaryDirectory->delete();
 
-        $content = $this->applyMetadata($content);
+        $content = $this->applyPostProcessors($content);
 
         Storage::disk($diskName)->put($path, $content, $this->visibility);
 
@@ -487,6 +498,7 @@ class PdfBuilder implements Attachable, Responsable
         $options->scale = $this->scale;
         $options->pageRanges = $this->pageRanges;
         $options->tagged = $this->tagged;
+        $options->password = $this->password;
 
         return $options;
     }
@@ -500,21 +512,41 @@ class PdfBuilder implements Attachable, Responsable
             $this->buildOptions(),
         );
 
-        return $this->applyMetadata($content);
+        return $this->applyPostProcessors($content);
     }
 
-    protected function applyMetadata(string $pdfContent): string
+    protected function applyPostProcessors(string $pdfContent): string
     {
-        if (! $this->hasMetadata()) {
-            return $pdfContent;
+        if ($this->hasMetadata()) {
+            $pdfContent = PdfMetadataWriter::write($pdfContent, $this->metadata);
         }
 
-        return PdfMetadataWriter::write($pdfContent, $this->metadata);
+        foreach ($this->postProcessors() as $postProcessor) {
+            $pdfContent = $postProcessor->process($pdfContent);
+        }
+
+        return $pdfContent;
     }
 
     protected function hasMetadata(): bool
     {
         return $this->metadata !== null && ! $this->metadata->isEmpty();
+    }
+
+    protected function hasPostProcessors(): bool
+    {
+        return $this->hasMetadata()
+            || $this->password !== null;
+    }
+
+    /**
+     * @return array<int, PdfPostProcessor>
+     */
+    protected function postProcessors(): array
+    {
+        return [
+            ...($this->password !== null ? [new PasswordProtectionPostProcessor($this->password)] : []),
+        ];
     }
 
     protected function configureBrowsershotDriver(PdfDriver $driver): void

--- a/src/PdfOptions.php
+++ b/src/PdfOptions.php
@@ -17,4 +17,6 @@ class PdfOptions
     public ?string $pageRanges = null;
 
     public bool $tagged = false;
+
+    public ?string $password = null;
 }

--- a/src/PostProcessing/PasswordProtectionPostProcessor.php
+++ b/src/PostProcessing/PasswordProtectionPostProcessor.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Spatie\LaravelPdf\PostProcessing;
+
+use setasign\FpdiProtection\FpdiProtection;
+use Spatie\TemporaryDirectory\TemporaryDirectory;
+
+class PasswordProtectionPostProcessor implements PdfPostProcessor
+{
+    public function __construct(
+        protected string $password,
+    ) {}
+
+    public function process(string $pdf): string
+    {
+        $temporaryDirectory = (new TemporaryDirectory)->create();
+
+        try {
+            $sourcePath = $temporaryDirectory->path('source.pdf');
+
+            file_put_contents($sourcePath, $pdf);
+
+            $protectedPdf = new FpdiProtection(useArcfourFallback: true);
+            $protectedPdf->setProtection($this->permissions(), $this->password);
+
+            $pageCount = $protectedPdf->setSourceFile($sourcePath);
+
+            for ($page = 1; $page <= $pageCount; $page++) {
+                $templateId = $protectedPdf->importPage($page);
+                $size = $protectedPdf->getTemplateSize($templateId);
+
+                $protectedPdf->AddPage($size['orientation'], [$size['width'], $size['height']]);
+                $protectedPdf->useTemplate($templateId);
+            }
+
+            return $protectedPdf->Output('S');
+        } finally {
+            $temporaryDirectory->delete();
+        }
+    }
+
+    protected function permissions(): array
+    {
+        return [
+            FpdiProtection::PERM_PRINT,
+            FpdiProtection::PERM_MODIFY,
+            FpdiProtection::PERM_COPY,
+            FpdiProtection::PERM_ANNOT,
+            FpdiProtection::PERM_FILL_FORM,
+            FpdiProtection::PERM_ACCESSIBILITY,
+            FpdiProtection::PERM_ASSEMBLE,
+            FpdiProtection::PERM_DIGITAL_PRINT,
+        ];
+    }
+}

--- a/src/PostProcessing/PdfPostProcessor.php
+++ b/src/PostProcessing/PdfPostProcessor.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\LaravelPdf\PostProcessing;
+
+interface PdfPostProcessor
+{
+    public function process(string $pdf): string;
+}

--- a/tests/Unit/FakePdfTest.php
+++ b/tests/Unit/FakePdfTest.php
@@ -274,6 +274,16 @@ it('can determine that tagged was set on a saved pdf', function () {
     });
 });
 
+it('can determine that password was set on a saved pdf', function () {
+    Pdf::view('test')
+        ->password('secret')
+        ->save('protected.pdf');
+
+    Pdf::assertSaved(function (PdfBuilder $pdf) {
+        return $pdf->password === 'secret';
+    });
+});
+
 it('can determine that metadata was set on a pdf response', function () {
     Route::get('pdf', function () {
         return pdf('test')

--- a/tests/Unit/GeneratePdfJobTest.php
+++ b/tests/Unit/GeneratePdfJobTest.php
@@ -182,6 +182,47 @@ it('saves a pdf with metadata to a disk', function () {
     expect($content)->toContain('/Title (Disk Invoice)');
 });
 
+it('saves a password protected pdf to a local path', function () {
+    $path = getTempPath('queued-protected.pdf');
+
+    $options = new PdfOptions;
+    $options->password = 'secret';
+
+    $job = new GeneratePdfJob(
+        html: '<h1>Hello with password</h1>',
+        headerHtml: null,
+        footerHtml: null,
+        options: $options,
+        path: $path,
+        driverName: 'dompdf',
+    );
+
+    $job->handle();
+
+    expect(file_get_contents($path))->toContain('/Encrypt');
+});
+
+it('saves a password protected pdf to a disk', function () {
+    Storage::fake('testing');
+
+    $options = new PdfOptions;
+    $options->password = 'secret';
+
+    $job = new GeneratePdfJob(
+        html: '<h1>Disk password test</h1>',
+        headerHtml: null,
+        footerHtml: null,
+        options: $options,
+        path: 'invoices/protected.pdf',
+        diskName: 'testing',
+        driverName: 'dompdf',
+    );
+
+    $job->handle();
+
+    expect(Storage::disk('testing')->get('invoices/protected.pdf'))->toContain('/Encrypt');
+});
+
 it('invokes catch callback on failure', function () {
     $caughtException = null;
 

--- a/tests/Unit/PasswordProtectionPostProcessorTest.php
+++ b/tests/Unit/PasswordProtectionPostProcessorTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use Spatie\LaravelPdf\Drivers\PdfDriver;
+use Spatie\LaravelPdf\Facades\Pdf;
+use Spatie\LaravelPdf\PdfOptions;
+use Spatie\LaravelPdf\PostProcessing\PasswordProtectionPostProcessor;
+
+it('password protects pdf content', function () {
+    $protectedPdf = (new PasswordProtectionPostProcessor('secret'))->process(testPdfContent());
+
+    expect($protectedPdf)
+        ->toStartWith('%PDF')
+        ->toContain('/Encrypt');
+});
+
+it('runs password protection after a driver generates pdf content', function () {
+    $driver = new class implements PdfDriver
+    {
+        public int $generateCalls = 0;
+
+        public int $saveCalls = 0;
+
+        public function generatePdf(string $html, ?string $headerHtml, ?string $footerHtml, PdfOptions $options): string
+        {
+            $this->generateCalls++;
+
+            return testPdfContent();
+        }
+
+        public function savePdf(string $html, ?string $headerHtml, ?string $footerHtml, PdfOptions $options, string $path): void
+        {
+            $this->saveCalls++;
+
+            file_put_contents($path, testPdfContent());
+        }
+    };
+
+    $targetPath = getTempPath('protected.pdf');
+
+    Pdf::html('<h1>Hello</h1>')
+        ->setDriver($driver)
+        ->password('secret')
+        ->save($targetPath);
+
+    expect($driver->generateCalls)->toBe(1)
+        ->and($driver->saveCalls)->toBe(0)
+        ->and(file_get_contents($targetPath))->toContain('/Encrypt');
+});
+
+it('stores the password on queued pdf options', function () {
+    Pdf::fake();
+
+    Pdf::html('<h1>Hello</h1>')
+        ->password('secret')
+        ->saveQueued('protected.pdf');
+
+    Pdf::assertQueued(function ($pdf) {
+        return invade($pdf)->buildOptions()->password === 'secret';
+    });
+});
+
+function testPdfContent(): string
+{
+    $pdf = new FPDF;
+    $pdf->AddPage();
+    $pdf->SetFont('Arial', '', 12);
+    $pdf->Cell(40, 10, 'Hello');
+
+    return $pdf->Output('S');
+}


### PR DESCRIPTION
## Summary

This PR adds driver-agnostic PDF password protection via a post-processing pipeline.

Instead of implementing encryption inside each driver, generated PDF bytes are passed through a shared post-processor after rendering. This keeps the feature compatible with all drivers, including Browsershot, Cloudflare, Gotenberg, WeasyPrint, Chrome, and DOMPDF.

## Usage

```php
Pdf::view('pdf.invoice', $data)
    ->password('secret123')
    ->save('invoice.pdf');
```

## Implementation

- Adds `PdfBuilder::password()`
- Stores the password on `PdfOptions` for queued PDF generation
- Introduces a `PdfPostProcessor` abstraction
- Adds `PasswordProtectionPostProcessor`
- Uses `setasign/fpdi-protection` to apply open-password protection in pure PHP
- Keeps existing driver implementations unchanged
- Preserves the existing direct-save path unless post-processing is required
- Applies post-processing consistently for local saves, disk saves, responses, attachments, and queued jobs

## Tests

- Added processor coverage
- Added builder/save pipeline coverage
- Added queued job coverage for local and disk saves
- Added fake PDF assertion coverage