### PR TITLE
Add readiness waiting and render caching

### DIFF
--- a/config/laravel-pdf.php
+++ b/config/laravel-pdf.php
@@ -37,10 +37,11 @@ return [
         'class' => DefaultPdfCache::class,
 
         /*
-         * When enabled, every PDF is cached without having to call `->cache()`.
-         * Call `->cache()` or `->dontCache()` on a PDF to override this.
+         * When set to true, every PDF is cached automatically without having
+         * to call `->cache()`. Call `->cache()` or `->dontCache()` on a PDF
+         * to override this.
          */
-        'enabled' => env('LARAVEL_PDF_CACHE_ENABLED', false),
+        'automatic' => env('LARAVEL_PDF_CACHE_AUTOMATIC', false),
 
         /*
          * The cache store to use. Leave null to use the default store.

--- a/config/laravel-pdf.php
+++ b/config/laravel-pdf.php
@@ -37,6 +37,12 @@ return [
         'class' => DefaultPdfCache::class,
 
         /*
+         * When enabled, every PDF is cached without having to call `->cache()`.
+         * Call `->cache()` or `->dontCache()` on a PDF to override this.
+         */
+        'enabled' => env('LARAVEL_PDF_CACHE_ENABLED', false),
+
+        /*
          * The cache store to use. Leave null to use the default store.
          */
         'store' => env('LARAVEL_PDF_CACHE_STORE'),
@@ -49,7 +55,7 @@ return [
         /*
          * The default lifetime in seconds. Leave null to cache forever.
          */
-        'ttl' => env('LARAVEL_PDF_CACHE_TTL'),
+        'ttl' => env('LARAVEL_PDF_CACHE_TTL', 60 * 60 * 24),
     ],
 
     /*

--- a/config/laravel-pdf.php
+++ b/config/laravel-pdf.php
@@ -12,21 +12,6 @@ return [
     'driver' => env('LARAVEL_PDF_DRIVER', 'browsershot'),
 
     /*
-     * The job class used for queued PDF generation.
-     * You can replace this with your own class that extends GeneratePdfJob
-     * to customize things like $tries, $timeout, $backoff, or default queue.
-     */
-    'job' => GeneratePdfJob::class,
-
-    /*
-     * The class used to encrypt and decrypt password-protected PDFs.
-     *
-     * More info in our docs:
-     * https://spatie.be/docs/laravel-pdf/v2/basic-usage/protecting-pdfs-with-a-password
-     */
-    'encrypter' => DefaultPdfEncrypter::class,
-
-    /*
      * Render caching. When you call `->cache()` on a PDF, the generated
      * content is stored so identical renders are served from the cache.
      *
@@ -174,4 +159,19 @@ return [
 
         'env_variables' => [],
     ],
+
+    /*
+     * The job class used for queued PDF generation.
+     * You can replace this with your own class that extends GeneratePdfJob
+     * to customize things like $tries, $timeout, $backoff, or default queue.
+     */
+    'job' => GeneratePdfJob::class,
+
+    /*
+     * The class used to encrypt and decrypt password-protected PDFs.
+     *
+     * More info in our docs:
+     * https://spatie.be/docs/laravel-pdf/v2/basic-usage/protecting-pdfs-with-a-password
+     */
+    'encrypter' => DefaultPdfEncrypter::class,
 ];

--- a/config/laravel-pdf.php
+++ b/config/laravel-pdf.php
@@ -1,5 +1,6 @@
 <?php
 
+use Spatie\LaravelPdf\Caching\DefaultPdfCache;
 use Spatie\LaravelPdf\Encryption\DefaultPdfEncrypter;
 use Spatie\LaravelPdf\Jobs\GeneratePdfJob;
 
@@ -24,6 +25,32 @@ return [
      * https://spatie.be/docs/laravel-pdf/v2/basic-usage/protecting-pdfs-with-a-password
      */
     'encrypter' => DefaultPdfEncrypter::class,
+
+    /*
+     * Render caching. When you call `->cache()` on a PDF, the generated
+     * content is stored so identical renders are served from the cache.
+     *
+     * Swap `class` for your own implementation of the PdfCache contract
+     * to fully customize how PDFs are keyed, stored, and expired.
+     */
+    'cache' => [
+        'class' => DefaultPdfCache::class,
+
+        /*
+         * The cache store to use. Leave null to use the default store.
+         */
+        'store' => env('LARAVEL_PDF_CACHE_STORE'),
+
+        /*
+         * The prefix prepended to every cache key.
+         */
+        'prefix' => 'laravel-pdf',
+
+        /*
+         * The default lifetime in seconds. Leave null to cache forever.
+         */
+        'ttl' => env('LARAVEL_PDF_CACHE_TTL'),
+    ],
 
     /*
      * Browsershot driver configuration.

--- a/docs/advanced-usage/caching-pdfs.md
+++ b/docs/advanced-usage/caching-pdfs.md
@@ -31,11 +31,11 @@ Pdf::view('pdf.invoice', ['invoice' => $invoice])
 
 ## Caching every PDF by default
 
-If you want every PDF to be cached without calling `cache()` each time, enable caching in the config file (or set `LARAVEL_PDF_CACHE_ENABLED=true` in your `.env`).
+If you want every PDF to be cached without calling `cache()` each time, turn on automatic caching in the config file (or set `LARAVEL_PDF_CACHE_AUTOMATIC=true` in your `.env`).
 
 ```php
 'cache' => [
-    'enabled' => env('LARAVEL_PDF_CACHE_ENABLED', true),
+    'automatic' => env('LARAVEL_PDF_CACHE_AUTOMATIC', true),
 ],
 ```
 
@@ -66,14 +66,14 @@ The caching behaviour is configured in the `cache` section of the `laravel-pdf` 
 ```php
 'cache' => [
     'class' => Spatie\LaravelPdf\Caching\DefaultPdfCache::class,
-    'enabled' => env('LARAVEL_PDF_CACHE_ENABLED', false),
+    'automatic' => env('LARAVEL_PDF_CACHE_AUTOMATIC', false),
     'store' => env('LARAVEL_PDF_CACHE_STORE'),
     'prefix' => 'laravel-pdf',
     'ttl' => env('LARAVEL_PDF_CACHE_TTL', 60 * 60 * 24),
 ],
 ```
 
-* `enabled`: when `true`, every PDF is cached without calling `cache()`. Defaults to `false`.
+* `automatic`: when `true`, every PDF is cached without calling `cache()`. Defaults to `false`.
 * `store`: the cache store to use. Leave it `null` to use your application's default store.
 * `prefix`: the prefix prepended to every cache key.
 * `ttl`: the default lifetime in seconds. Defaults to one day. Set it to `null` to cache forever.

--- a/docs/advanced-usage/caching-pdfs.md
+++ b/docs/advanced-usage/caching-pdfs.md
@@ -21,11 +21,29 @@ Caching applies to every output method, including `save()`, `download()`, `base6
 
 ## Setting a lifetime
 
-By default a cache entry lives for one day. Pass a lifetime (in seconds) to use a different duration.
+By default a cache entry lives for one day. Pass a lifetime to use a different duration. It accepts a number of seconds, a `DateInterval`, or a `DateTimeInterface`.
 
 ```php
 Pdf::view('pdf.invoice', ['invoice' => $invoice])
-    ->cache(3600)
+    ->cache(3600) // seconds
+    ->save('invoice.pdf');
+```
+
+You can use Laravel's duration helpers (`minutes`, `hours`, `days`) for a more expressive lifetime.
+
+```php
+use function Illuminate\Support\hours;
+
+Pdf::view('pdf.invoice', ['invoice' => $invoice])
+    ->cache(hours(2))
+    ->save('invoice.pdf');
+```
+
+A Carbon instance (or any `DateTimeInterface`) works too, expiring the entry at that moment.
+
+```php
+Pdf::view('pdf.invoice', ['invoice' => $invoice])
+    ->cache(now()->endOfDay())
     ->save('invoice.pdf');
 ```
 

--- a/docs/advanced-usage/caching-pdfs.md
+++ b/docs/advanced-usage/caching-pdfs.md
@@ -29,21 +29,21 @@ Pdf::view('pdf.invoice', ['invoice' => $invoice])
     ->save('invoice.pdf');
 ```
 
-You can use Laravel's duration helpers (`minutes`, `hours`, `days`) for a more expressive lifetime.
+A Carbon instance (or any `DateTimeInterface`) works too, expiring the entry at that moment.
+
+```php
+Pdf::view('pdf.invoice', ['invoice' => $invoice])
+    ->cache(now()->endOfDay())
+    ->save('invoice.pdf');
+```
+
+On Laravel versions that ship the duration helpers (`minutes`, `hours`, `days`), you can use those for an even more expressive lifetime.
 
 ```php
 use function Illuminate\Support\hours;
 
 Pdf::view('pdf.invoice', ['invoice' => $invoice])
     ->cache(hours(2))
-    ->save('invoice.pdf');
-```
-
-A Carbon instance (or any `DateTimeInterface`) works too, expiring the entry at that moment.
-
-```php
-Pdf::view('pdf.invoice', ['invoice' => $invoice])
-    ->cache(now()->endOfDay())
     ->save('invoice.pdf');
 ```
 

--- a/docs/advanced-usage/caching-pdfs.md
+++ b/docs/advanced-usage/caching-pdfs.md
@@ -1,0 +1,90 @@
+---
+title: Caching PDFs
+weight: 6
+---
+
+Rendering a PDF with a Chromium based driver is relatively expensive. When the same document is generated repeatedly, you can cache the rendered result so identical renders are served from the cache instead of being generated again.
+
+## Caching a render
+
+Call `cache()` on the builder. The first render is generated and stored. Every subsequent render with identical input is served from the cache.
+
+```php
+use Spatie\LaravelPdf\Facades\Pdf;
+
+Pdf::view('pdf.invoice', ['invoice' => $invoice])
+    ->cache()
+    ->download('invoice.pdf');
+```
+
+Caching applies to every output method, including `save()`, `download()`, `base64()`, returning the PDF as a response, and attaching it to a mail.
+
+## Setting a lifetime
+
+By default the cache entry is stored forever. Pass a lifetime (in seconds) to expire it after a while.
+
+```php
+Pdf::view('pdf.invoice', ['invoice' => $invoice])
+    ->cache(3600)
+    ->save('invoice.pdf');
+```
+
+## How the cache key is determined
+
+By default the cache key is derived from everything that influences the output: the rendered HTML, the header and footer, all formatting options, the metadata, and the encryption settings. Two renders that differ in any of these get separate cache entries, so you never accidentally serve the wrong PDF.
+
+If you want full control over the key, pass your own as the second argument. This is useful when you can describe a render with a stable identifier, such as an invoice id.
+
+```php
+Pdf::view('pdf.invoice', ['invoice' => $invoice])
+    ->cache(key: "invoice-{$invoice->id}")
+    ->save('invoice.pdf');
+```
+
+## Configuring the cache
+
+The caching behaviour is configured in the `cache` section of the `laravel-pdf` config file.
+
+```php
+'cache' => [
+    'class' => Spatie\LaravelPdf\Caching\DefaultPdfCache::class,
+    'store' => env('LARAVEL_PDF_CACHE_STORE'),
+    'prefix' => 'laravel-pdf',
+    'ttl' => env('LARAVEL_PDF_CACHE_TTL'),
+],
+```
+
+* `store`: the cache store to use. Leave it `null` to use your application's default store.
+* `prefix`: the prefix prepended to every cache key.
+* `ttl`: the default lifetime in seconds. Leave it `null` to cache forever.
+
+## Customizing the caching behaviour
+
+If you need to change how PDFs are keyed, stored, or expired, you can replace the entire caching implementation. Create a class that implements the `Spatie\LaravelPdf\Caching\PdfCache` contract.
+
+```php
+namespace App\Support;
+
+use Closure;
+use Spatie\LaravelPdf\Caching\PdfCache;
+
+class MyPdfCache implements PdfCache
+{
+    public function remember(string $fingerprint, ?string $key, ?int $ttl, Closure $generate): string
+    {
+        // Return the cached PDF content, generating and storing it when needed.
+    }
+}
+```
+
+Register it in the `cache.class` key of the config file.
+
+```php
+'cache' => [
+    'class' => App\Support\MyPdfCache::class,
+],
+```
+
+## Caching and queued generation
+
+Caching applies to PDFs generated synchronously. PDFs generated with [queued generation](/docs/laravel-pdf/v2/basic-usage/queued-pdf-generation) are not cached.

--- a/docs/advanced-usage/caching-pdfs.md
+++ b/docs/advanced-usage/caching-pdfs.md
@@ -21,12 +21,30 @@ Caching applies to every output method, including `save()`, `download()`, `base6
 
 ## Setting a lifetime
 
-By default the cache entry is stored forever. Pass a lifetime (in seconds) to expire it after a while.
+By default a cache entry lives for one day. Pass a lifetime (in seconds) to use a different duration.
 
 ```php
 Pdf::view('pdf.invoice', ['invoice' => $invoice])
     ->cache(3600)
     ->save('invoice.pdf');
+```
+
+## Caching every PDF by default
+
+If you want every PDF to be cached without calling `cache()` each time, enable caching in the config file (or set `LARAVEL_PDF_CACHE_ENABLED=true` in your `.env`).
+
+```php
+'cache' => [
+    'enabled' => env('LARAVEL_PDF_CACHE_ENABLED', true),
+],
+```
+
+With caching enabled, calling `cache()` still works to override the lifetime or key for a specific PDF. To skip the cache for a single PDF, call `dontCache()`.
+
+```php
+Pdf::view('pdf.receipt', ['receipt' => $receipt])
+    ->dontCache()
+    ->download('receipt.pdf');
 ```
 
 ## How the cache key is determined
@@ -48,15 +66,17 @@ The caching behaviour is configured in the `cache` section of the `laravel-pdf` 
 ```php
 'cache' => [
     'class' => Spatie\LaravelPdf\Caching\DefaultPdfCache::class,
+    'enabled' => env('LARAVEL_PDF_CACHE_ENABLED', false),
     'store' => env('LARAVEL_PDF_CACHE_STORE'),
     'prefix' => 'laravel-pdf',
-    'ttl' => env('LARAVEL_PDF_CACHE_TTL'),
+    'ttl' => env('LARAVEL_PDF_CACHE_TTL', 60 * 60 * 24),
 ],
 ```
 
+* `enabled`: when `true`, every PDF is cached without calling `cache()`. Defaults to `false`.
 * `store`: the cache store to use. Leave it `null` to use your application's default store.
 * `prefix`: the prefix prepended to every cache key.
-* `ttl`: the default lifetime in seconds. Leave it `null` to cache forever.
+* `ttl`: the default lifetime in seconds. Defaults to one day. Set it to `null` to cache forever.
 
 ## Customizing the caching behaviour
 

--- a/docs/advanced-usage/caching-pdfs.md
+++ b/docs/advanced-usage/caching-pdfs.md
@@ -105,6 +105,17 @@ Register it in the `cache.class` key of the config file.
 ],
 ```
 
+## Caching and `withBrowsershot()`
+
+A closure passed to `withBrowsershot()` can change the output, but it cannot be added to the cache key. Caching a PDF that is customized this way throws an exception unless you pass an explicit key, which makes you responsible for keeping it unique.
+
+```php
+Pdf::view('pdf.invoice', ['invoice' => $invoice])
+    ->withBrowsershot(fn ($browsershot) => $browsershot->setRemoteInstance('127.0.0.1', 9222))
+    ->cache(key: "invoice-{$invoice->id}")
+    ->save('invoice.pdf');
+```
+
 ## Caching and queued generation
 
 Caching applies to PDFs generated synchronously. PDFs generated with [queued generation](/docs/laravel-pdf/v2/basic-usage/queued-pdf-generation) are not cached.

--- a/docs/advanced-usage/waiting-for-readiness.md
+++ b/docs/advanced-usage/waiting-for-readiness.md
@@ -1,0 +1,60 @@
+---
+title: Waiting for readiness
+weight: 5
+---
+
+When you render JavaScript heavy views (charts, maps, web fonts, or content loaded asynchronously), the PDF can be captured before everything has finished rendering. The result is an empty chart or a missing font.
+
+Instead of guessing with arbitrary delays, you can wait for an explicit readiness signal. Set a flag in your view once everything is done, and the PDF will only be captured after that flag becomes true.
+
+## Signalling readiness from your view
+
+In your Blade view, set `window.pdfReady` to `true` once the page is ready to be captured.
+
+```blade
+<canvas id="chart"></canvas>
+
+<script>
+    renderChart('#chart').then(() => {
+        window.pdfReady = true;
+    });
+</script>
+```
+
+## Waiting for the flag
+
+Call `waitUntilReady()` on the builder. The PDF will be captured only after `window.pdfReady === true`.
+
+```php
+use Spatie\LaravelPdf\Facades\Pdf;
+
+Pdf::view('pdf.report', ['report' => $report])
+    ->waitUntilReady()
+    ->save('report.pdf');
+```
+
+## Using a custom expression
+
+If you prefer your own readiness condition, pass any JavaScript expression that evaluates to a truthy value.
+
+```php
+Pdf::view('pdf.report')
+    ->waitUntilReady('window.charts.every(chart => chart.rendered)')
+    ->save('report.pdf');
+```
+
+## Setting a timeout
+
+By default the renderer waits up to 30 seconds. You can pass a custom timeout (in milliseconds) as the second argument.
+
+```php
+Pdf::view('pdf.report')
+    ->waitUntilReady('window.pdfReady === true', timeout: 5000)
+    ->save('report.pdf');
+```
+
+## Driver support
+
+Waiting for readiness requires a driver that can execute JavaScript. It is supported by the [Browsershot](/docs/laravel-pdf/v2/drivers/customizing-browsershot) and [Chrome](/docs/laravel-pdf/v2/drivers/using-the-chrome-driver) drivers.
+
+Calling `waitUntilReady()` while a driver that cannot run JavaScript is active (such as DOMPDF or WeasyPrint) throws a `CouldNotGeneratePdf` exception.

--- a/src/Caching/DefaultPdfCache.php
+++ b/src/Caching/DefaultPdfCache.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Spatie\LaravelPdf\Caching;
+
+use Closure;
+use Illuminate\Support\Facades\Cache;
+
+class DefaultPdfCache implements PdfCache
+{
+    public function remember(string $fingerprint, ?string $key, ?int $ttl, Closure $generate): string
+    {
+        $store = Cache::store(config('laravel-pdf.cache.store'));
+
+        $cacheKey = $this->cacheKey($fingerprint, $key);
+
+        $ttl ??= config('laravel-pdf.cache.ttl');
+
+        $encode = fn () => base64_encode($generate());
+
+        $cached = $ttl === null
+            ? $store->rememberForever($cacheKey, $encode)
+            : $store->remember($cacheKey, $ttl, $encode);
+
+        return base64_decode($cached);
+    }
+
+    protected function cacheKey(string $fingerprint, ?string $key): string
+    {
+        $prefix = config('laravel-pdf.cache.prefix', 'laravel-pdf');
+
+        return $prefix.':'.($key ?? sha1($fingerprint));
+    }
+}

--- a/src/Caching/DefaultPdfCache.php
+++ b/src/Caching/DefaultPdfCache.php
@@ -3,11 +3,13 @@
 namespace Spatie\LaravelPdf\Caching;
 
 use Closure;
+use DateInterval;
+use DateTimeInterface;
 use Illuminate\Support\Facades\Cache;
 
 class DefaultPdfCache implements PdfCache
 {
-    public function remember(string $fingerprint, ?string $key, ?int $ttl, Closure $generate): string
+    public function remember(string $fingerprint, ?string $key, DateTimeInterface|DateInterval|int|null $ttl, Closure $generate): string
     {
         $store = Cache::store(config('laravel-pdf.cache.store'));
 

--- a/src/Caching/PdfCache.php
+++ b/src/Caching/PdfCache.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\LaravelPdf\Caching;
+
+use Closure;
+
+interface PdfCache
+{
+    /**
+     * Return the cached PDF content for the given render, generating and
+     * storing it first when it is not cached yet.
+     *
+     * @param  string  $fingerprint  A string uniquely describing the render inputs.
+     * @param  ?string  $key  A user-supplied cache key that overrides the fingerprint.
+     * @param  ?int  $ttl  The lifetime in seconds, or null to cache forever.
+     * @param  Closure(): string  $generate  Generates the (post-processed) PDF content.
+     */
+    public function remember(string $fingerprint, ?string $key, ?int $ttl, Closure $generate): string;
+}

--- a/src/Caching/PdfCache.php
+++ b/src/Caching/PdfCache.php
@@ -3,6 +3,8 @@
 namespace Spatie\LaravelPdf\Caching;
 
 use Closure;
+use DateInterval;
+use DateTimeInterface;
 
 interface PdfCache
 {
@@ -12,8 +14,8 @@ interface PdfCache
      *
      * @param  string  $fingerprint  A string uniquely describing the render inputs.
      * @param  ?string  $key  A user-supplied cache key that overrides the fingerprint.
-     * @param  ?int  $ttl  The lifetime in seconds, or null to cache forever.
+     * @param  DateTimeInterface|DateInterval|int|null  $ttl  The lifetime in seconds (or as a date/interval), or null to cache forever.
      * @param  Closure(): string  $generate  Generates the (post-processed) PDF content.
      */
-    public function remember(string $fingerprint, ?string $key, ?int $ttl, Closure $generate): string;
+    public function remember(string $fingerprint, ?string $key, DateTimeInterface|DateInterval|int|null $ttl, Closure $generate): string;
 }

--- a/src/Drivers/BrowsershotDriver.php
+++ b/src/Drivers/BrowsershotDriver.php
@@ -113,7 +113,7 @@ class BrowsershotDriver implements PdfDriver, SupportsReadiness
         }
 
         if ($options->waitForReady !== null) {
-            $browsershot->waitForFunction($options->waitForReady, null, $options->waitForReadyTimeout ?? 0);
+            $browsershot->waitForFunction($options->waitForReady, null, $options->waitForReadyTimeout ?? 30000);
         }
 
         $this->applyConfigurationDefaults($browsershot);

--- a/src/Drivers/BrowsershotDriver.php
+++ b/src/Drivers/BrowsershotDriver.php
@@ -9,7 +9,7 @@ use Spatie\LaravelPdf\Exceptions\CouldNotGeneratePdf;
 use Spatie\LaravelPdf\PdfOptions;
 use Wnx\SidecarBrowsershot\BrowsershotLambda;
 
-class BrowsershotDriver implements PdfDriver
+class BrowsershotDriver implements PdfDriver, SupportsReadiness
 {
     protected array $config;
 
@@ -110,6 +110,10 @@ class BrowsershotDriver implements PdfDriver
 
         if ($options->tagged) {
             $browsershot->taggedPdf();
+        }
+
+        if ($options->waitForReady !== null) {
+            $browsershot->waitForFunction($options->waitForReady, null, $options->waitForReadyTimeout ?? 0);
         }
 
         $this->applyConfigurationDefaults($browsershot);

--- a/src/Drivers/ChromeDriver.php
+++ b/src/Drivers/ChromeDriver.php
@@ -95,7 +95,7 @@ class ChromeDriver implements PdfDriver, SupportsReadiness
 
         $timeout = $options->waitForReadyTimeout ?? 30000;
         $deadline = microtime(true) + ($timeout / 1000);
-        $expression = "(() => Boolean({$options->waitForReady}))()";
+        $expression = "(() => { try { return Boolean({$options->waitForReady}); } catch (error) { return false; } })()";
 
         do {
             if ($page->evaluate($expression)->getReturnValue()) {

--- a/src/Drivers/ChromeDriver.php
+++ b/src/Drivers/ChromeDriver.php
@@ -4,11 +4,12 @@ namespace Spatie\LaravelPdf\Drivers;
 
 use HeadlessChromium\Browser\ProcessAwareBrowser;
 use HeadlessChromium\BrowserFactory;
+use HeadlessChromium\Page;
 use Spatie\LaravelPdf\Enums\Orientation;
 use Spatie\LaravelPdf\Exceptions\CouldNotGeneratePdf;
 use Spatie\LaravelPdf\PdfOptions;
 
-class ChromeDriver implements PdfDriver
+class ChromeDriver implements PdfDriver, SupportsReadiness
 {
     protected array $config;
 
@@ -56,6 +57,8 @@ class ChromeDriver implements PdfDriver
             $page = $browser->createPage();
             $page->setHtml($html, $this->config['timeout'] ?? 30000);
 
+            $this->waitForReadiness($page, $options);
+
             $pdfOptions = $this->buildPdfOptions($headerHtml, $footerHtml, $options);
             $pdf = $page->pdf($pdfOptions);
 
@@ -73,6 +76,8 @@ class ChromeDriver implements PdfDriver
             $page = $browser->createPage();
             $page->setHtml($html, $this->config['timeout'] ?? 30000);
 
+            $this->waitForReadiness($page, $options);
+
             $pdfOptions = $this->buildPdfOptions($headerHtml, $footerHtml, $options);
             $pdf = $page->pdf($pdfOptions);
 
@@ -80,6 +85,25 @@ class ChromeDriver implements PdfDriver
         } finally {
             $browser->close();
         }
+    }
+
+    protected function waitForReadiness(Page $page, PdfOptions $options): void
+    {
+        if ($options->waitForReady === null) {
+            return;
+        }
+
+        $timeout = $options->waitForReadyTimeout ?? 30000;
+        $deadline = microtime(true) + ($timeout / 1000);
+        $expression = "(() => Boolean({$options->waitForReady}))()";
+
+        do {
+            if ($page->evaluate($expression)->getReturnValue()) {
+                return;
+            }
+
+            usleep(100_000);
+        } while (microtime(true) < $deadline);
     }
 
     protected function createBrowser(): ProcessAwareBrowser

--- a/src/Drivers/SupportsReadiness.php
+++ b/src/Drivers/SupportsReadiness.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\LaravelPdf\Drivers;
+
+/**
+ * Marker interface for drivers that can wait for an explicit readiness
+ * signal (a JavaScript expression) before capturing the PDF.
+ */
+interface SupportsReadiness {}

--- a/src/Exceptions/CouldNotGeneratePdf.php
+++ b/src/Exceptions/CouldNotGeneratePdf.php
@@ -63,4 +63,12 @@ class CouldNotGeneratePdf extends Exception
             .'Closures passed to withBrowsershot() cannot be serialized for the queue.'
         );
     }
+
+    public static function driverDoesNotSupportReadiness(string $driverName): self
+    {
+        return new self(
+            "The [{$driverName}] driver does not support waiting for readiness. "
+            .'Use a Chromium-based driver such as browsershot or chrome.'
+        );
+    }
 }

--- a/src/Exceptions/CouldNotGeneratePdf.php
+++ b/src/Exceptions/CouldNotGeneratePdf.php
@@ -64,6 +64,14 @@ class CouldNotGeneratePdf extends Exception
         );
     }
 
+    public static function cannotCacheWithBrowsershotClosure(): self
+    {
+        return new self(
+            'Cannot cache a PDF that is customized with withBrowsershot(). '
+            .'Closures cannot be added to the cache key. Pass an explicit key with cache(key: ...) to cache anyway.'
+        );
+    }
+
     public static function driverDoesNotSupportReadiness(string $driverName): self
     {
         return new self(

--- a/src/PdfBuilder.php
+++ b/src/PdfBuilder.php
@@ -3,6 +3,7 @@
 namespace Spatie\LaravelPdf;
 
 use Closure;
+use DateInterval;
 use DateTimeInterface;
 use Illuminate\Contracts\Mail\Attachable;
 use Illuminate\Contracts\Support\Responsable;
@@ -93,7 +94,7 @@ class PdfBuilder implements Attachable, Responsable
 
     protected ?bool $shouldCache = null;
 
-    protected ?int $cacheTtl = null;
+    protected DateTimeInterface|DateInterval|int|null $cacheTtl = null;
 
     protected ?string $cacheKey = null;
 
@@ -339,7 +340,7 @@ class PdfBuilder implements Attachable, Responsable
         return $this;
     }
 
-    public function cache(?int $ttl = null, ?string $key = null): self
+    public function cache(DateTimeInterface|DateInterval|int|null $ttl = null, ?string $key = null): self
     {
         $this->shouldCache = true;
 

--- a/src/PdfBuilder.php
+++ b/src/PdfBuilder.php
@@ -13,7 +13,9 @@ use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Dumpable;
 use Illuminate\Support\Traits\Macroable;
+use Spatie\LaravelPdf\Caching\PdfCache;
 use Spatie\LaravelPdf\Drivers\PdfDriver;
+use Spatie\LaravelPdf\Drivers\SupportsReadiness;
 use Spatie\LaravelPdf\Encryption\PdfEncryption;
 use Spatie\LaravelPdf\Enums\Format;
 use Spatie\LaravelPdf\Enums\Orientation;
@@ -65,6 +67,10 @@ class PdfBuilder implements Attachable, Responsable
 
     public bool $tagged = false;
 
+    public ?string $waitForReady = null;
+
+    public ?int $waitForReadyTimeout = null;
+
     public ?PdfMetadata $metadata = null;
 
     public ?PdfEncryption $encryption = null;
@@ -84,6 +90,12 @@ class PdfBuilder implements Attachable, Responsable
     protected ?PdfDriver $driver = null;
 
     protected ?string $driverName = null;
+
+    protected bool $shouldCache = false;
+
+    protected ?int $cacheTtl = null;
+
+    protected ?string $cacheKey = null;
 
     public function setDriver(PdfDriver $driver): self
     {
@@ -113,7 +125,24 @@ class PdfBuilder implements Attachable, Responsable
 
         $this->configureBrowsershotDriver($driver);
 
+        $this->ensureDriverSupportsReadiness($driver);
+
         return $driver;
+    }
+
+    protected function ensureDriverSupportsReadiness(PdfDriver $driver): void
+    {
+        if ($this->waitForReady === null) {
+            return;
+        }
+
+        if ($driver instanceof SupportsReadiness) {
+            return;
+        }
+
+        throw CouldNotGeneratePdf::driverDoesNotSupportReadiness(
+            $this->driverName ?? config('laravel-pdf.driver', 'browsershot'),
+        );
     }
 
     public function view(string $view, array $data = []): self
@@ -301,6 +330,26 @@ class PdfBuilder implements Attachable, Responsable
         return $this;
     }
 
+    public function waitUntilReady(?string $expression = null, ?int $timeout = null): self
+    {
+        $this->waitForReady = $expression ?? 'window.pdfReady === true';
+
+        $this->waitForReadyTimeout = $timeout;
+
+        return $this;
+    }
+
+    public function cache(?int $ttl = null, ?string $key = null): self
+    {
+        $this->shouldCache = true;
+
+        $this->cacheTtl = $ttl;
+
+        $this->cacheKey = $key;
+
+        return $this;
+    }
+
     public function meta(
         ?string $title = null,
         ?string $author = null,
@@ -364,7 +413,7 @@ class PdfBuilder implements Attachable, Responsable
             return $this->saveOnDisk($this->diskName, $path);
         }
 
-        if ($this->hasPostProcessors()) {
+        if ($this->shouldCache || $this->hasPostProcessors()) {
             file_put_contents($path, $this->generatePdfContent());
 
             return $this;
@@ -426,6 +475,12 @@ class PdfBuilder implements Attachable, Responsable
 
     protected function saveOnDisk(string $diskName, string $path): self
     {
+        if ($this->shouldCache) {
+            Storage::disk($diskName)->put($path, $this->generatePdfContent(), $this->visibility);
+
+            return $this;
+        }
+
         $fileName = pathinfo($path, PATHINFO_BASENAME);
 
         $temporaryDirectory = (new TemporaryDirectory)->create();
@@ -509,18 +564,34 @@ class PdfBuilder implements Attachable, Responsable
         $options->pageRanges = $this->pageRanges;
         $options->tagged = $this->tagged;
         $options->encryption = $this->encryption;
+        $options->waitForReady = $this->waitForReady;
+        $options->waitForReadyTimeout = $this->waitForReadyTimeout;
 
         return $options;
     }
 
     public function generatePdfContent(): string
     {
-        $content = $this->getDriver()->generatePdf(
-            $this->getHtml(),
-            $this->getHeaderHtml(),
-            $this->getFooterHtml(),
-            $this->buildOptions(),
+        $html = $this->getHtml();
+        $headerHtml = $this->getHeaderHtml();
+        $footerHtml = $this->getFooterHtml();
+        $options = $this->buildOptions();
+
+        if (! $this->shouldCache) {
+            return $this->processPdfContent($html, $headerHtml, $footerHtml, $options);
+        }
+
+        return app(PdfCache::class)->remember(
+            serialize([$html, $headerHtml, $footerHtml, $options, $this->metadata]),
+            $this->cacheKey,
+            $this->cacheTtl,
+            fn () => $this->processPdfContent($html, $headerHtml, $footerHtml, $options),
         );
+    }
+
+    protected function processPdfContent(string $html, ?string $headerHtml, ?string $footerHtml, PdfOptions $options): string
+    {
+        $content = $this->getDriver()->generatePdf($html, $headerHtml, $footerHtml, $options);
 
         return $this->applyPostProcessors($content);
     }

--- a/src/PdfBuilder.php
+++ b/src/PdfBuilder.php
@@ -359,7 +359,7 @@ class PdfBuilder implements Attachable, Responsable
 
     protected function shouldCache(): bool
     {
-        return $this->shouldCache ?? config('laravel-pdf.cache.enabled', false);
+        return $this->shouldCache ?? config('laravel-pdf.cache.automatic', false);
     }
 
     public function meta(

--- a/src/PdfBuilder.php
+++ b/src/PdfBuilder.php
@@ -593,8 +593,12 @@ class PdfBuilder implements Attachable, Responsable
             return $this->processPdfContent($html, $headerHtml, $footerHtml, $options);
         }
 
+        if ($this->customizeBrowsershot && $this->cacheKey === null) {
+            throw CouldNotGeneratePdf::cannotCacheWithBrowsershotClosure();
+        }
+
         return app(PdfCache::class)->remember(
-            serialize([$html, $headerHtml, $footerHtml, $options, $this->metadata]),
+            $this->cacheFingerprint($html, $headerHtml, $footerHtml, $options),
             $this->cacheKey,
             $this->cacheTtl,
             fn () => $this->processPdfContent($html, $headerHtml, $footerHtml, $options),
@@ -606,6 +610,19 @@ class PdfBuilder implements Attachable, Responsable
         $content = $this->getDriver()->generatePdf($html, $headerHtml, $footerHtml, $options);
 
         return $this->applyPostProcessors($content);
+    }
+
+    protected function cacheFingerprint(string $html, ?string $headerHtml, ?string $footerHtml, PdfOptions $options): string
+    {
+        return serialize([
+            $html,
+            $headerHtml,
+            $footerHtml,
+            $options,
+            $this->metadata,
+            $this->driverName,
+            $this->onLambda,
+        ]);
     }
 
     protected function applyPostProcessors(string $pdfContent): string

--- a/src/PdfBuilder.php
+++ b/src/PdfBuilder.php
@@ -91,7 +91,7 @@ class PdfBuilder implements Attachable, Responsable
 
     protected ?string $driverName = null;
 
-    protected bool $shouldCache = false;
+    protected ?bool $shouldCache = null;
 
     protected ?int $cacheTtl = null;
 
@@ -350,6 +350,18 @@ class PdfBuilder implements Attachable, Responsable
         return $this;
     }
 
+    public function dontCache(): self
+    {
+        $this->shouldCache = false;
+
+        return $this;
+    }
+
+    protected function shouldCache(): bool
+    {
+        return $this->shouldCache ?? config('laravel-pdf.cache.enabled', false);
+    }
+
     public function meta(
         ?string $title = null,
         ?string $author = null,
@@ -413,7 +425,7 @@ class PdfBuilder implements Attachable, Responsable
             return $this->saveOnDisk($this->diskName, $path);
         }
 
-        if ($this->shouldCache || $this->hasPostProcessors()) {
+        if ($this->shouldCache() || $this->hasPostProcessors()) {
             file_put_contents($path, $this->generatePdfContent());
 
             return $this;
@@ -475,7 +487,7 @@ class PdfBuilder implements Attachable, Responsable
 
     protected function saveOnDisk(string $diskName, string $path): self
     {
-        if ($this->shouldCache) {
+        if ($this->shouldCache()) {
             Storage::disk($diskName)->put($path, $this->generatePdfContent(), $this->visibility);
 
             return $this;
@@ -577,7 +589,7 @@ class PdfBuilder implements Attachable, Responsable
         $footerHtml = $this->getFooterHtml();
         $options = $this->buildOptions();
 
-        if (! $this->shouldCache) {
+        if (! $this->shouldCache()) {
             return $this->processPdfContent($html, $headerHtml, $footerHtml, $options);
         }
 

--- a/src/PdfOptions.php
+++ b/src/PdfOptions.php
@@ -21,4 +21,8 @@ class PdfOptions
     public bool $tagged = false;
 
     public ?PdfEncryption $encryption = null;
+
+    public ?string $waitForReady = null;
+
+    public ?int $waitForReadyTimeout = null;
 }

--- a/src/PdfServiceProvider.php
+++ b/src/PdfServiceProvider.php
@@ -5,6 +5,8 @@ namespace Spatie\LaravelPdf;
 use Illuminate\Support\Facades\Blade;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Spatie\LaravelPdf\Caching\DefaultPdfCache;
+use Spatie\LaravelPdf\Caching\PdfCache;
 use Spatie\LaravelPdf\Drivers\BrowsershotDriver;
 use Spatie\LaravelPdf\Drivers\ChromeDriver;
 use Spatie\LaravelPdf\Drivers\CloudflareDriver;
@@ -67,6 +69,10 @@ class PdfServiceProvider extends PackageServiceProvider
 
         $this->app->bind(PdfEncrypter::class, function () {
             return app(config('laravel-pdf.encrypter', DefaultPdfEncrypter::class));
+        });
+
+        $this->app->bind(PdfCache::class, function () {
+            return app(config('laravel-pdf.cache.class', DefaultPdfCache::class));
         });
     }
 

--- a/tests/Integration/CacheIntegrationTest.php
+++ b/tests/Integration/CacheIntegrationTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Support\Facades\Cache;
+use Spatie\LaravelPdf\Facades\Pdf;
+
+beforeEach(function () {
+    Cache::flush();
+});
+
+it('serves identical bytes from the cache on the second render', function () {
+    retryOnFlake(function () {
+        $first = Pdf::view('test')->cache()->base64();
+        $second = Pdf::view('test')->cache()->base64();
+
+        expect($second)->toBe($first)
+            ->and(base64_decode($first))->toStartWith('%PDF');
+    });
+});

--- a/tests/Integration/ReadinessIntegrationTest.php
+++ b/tests/Integration/ReadinessIntegrationTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use Spatie\LaravelPdf\Facades\Pdf;
+
+beforeEach(function () {
+    $this->targetPath = getTempPath('readiness.pdf');
+});
+
+it('waits for the readiness flag before capturing the pdf', function () {
+    retryOnFlake(function () {
+        Pdf::view('readiness')
+            ->waitUntilReady()
+            ->save($this->targetPath);
+
+        expect($this->targetPath)->toContainText('ready for capture');
+    });
+});

--- a/tests/TestSupport/FakeDriver.php
+++ b/tests/TestSupport/FakeDriver.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Spatie\LaravelPdf\Tests\TestSupport;
+
+use Spatie\LaravelPdf\Drivers\PdfDriver;
+use Spatie\LaravelPdf\Drivers\SupportsReadiness;
+use Spatie\LaravelPdf\PdfOptions;
+
+class FakeDriver implements PdfDriver, SupportsReadiness
+{
+    public int $generateCount = 0;
+
+    public int $saveCount = 0;
+
+    public ?PdfOptions $lastOptions = null;
+
+    public ?string $lastHtml = null;
+
+    public function __construct(public string $content = '%PDF-fake') {}
+
+    public function generatePdf(string $html, ?string $headerHtml, ?string $footerHtml, PdfOptions $options): string
+    {
+        $this->generateCount++;
+        $this->lastOptions = $options;
+        $this->lastHtml = $html;
+
+        return $this->content;
+    }
+
+    public function savePdf(string $html, ?string $headerHtml, ?string $footerHtml, PdfOptions $options, string $path): void
+    {
+        $this->saveCount++;
+        $this->lastOptions = $options;
+        $this->lastHtml = $html;
+
+        file_put_contents($path, $this->content);
+    }
+}

--- a/tests/Unit/BrowsershotDriverTest.php
+++ b/tests/Unit/BrowsershotDriverTest.php
@@ -21,6 +21,17 @@ it('configures browsershot to wait for the readiness expression', function () {
     expect(invade($browsershot)->additionalOptions['functionTimeout'])->toBe(5000);
 });
 
+it('defaults the readiness timeout to 30 seconds', function () {
+    $driver = new BrowsershotDriver;
+
+    $options = new PdfOptions;
+    $options->waitForReady = 'window.pdfReady === true';
+
+    $browsershot = invade($driver)->buildBrowsershot('<p>hi</p>', null, null, $options);
+
+    expect(invade($browsershot)->additionalOptions['functionTimeout'])->toBe(30000);
+});
+
 it('does not configure a wait function when readiness is not requested', function () {
     $driver = new BrowsershotDriver;
 

--- a/tests/Unit/BrowsershotDriverTest.php
+++ b/tests/Unit/BrowsershotDriverTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use Spatie\LaravelPdf\Drivers\BrowsershotDriver;
+use Spatie\LaravelPdf\Drivers\SupportsReadiness;
+use Spatie\LaravelPdf\PdfOptions;
+
+it('supports readiness', function () {
+    expect(new BrowsershotDriver)->toBeInstanceOf(SupportsReadiness::class);
+});
+
+it('configures browsershot to wait for the readiness expression', function () {
+    $driver = new BrowsershotDriver;
+
+    $options = new PdfOptions;
+    $options->waitForReady = 'window.pdfReady === true';
+    $options->waitForReadyTimeout = 5000;
+
+    $browsershot = invade($driver)->buildBrowsershot('<p>hi</p>', null, null, $options);
+
+    expect(invade($browsershot)->additionalOptions['function'])->toBe('window.pdfReady === true');
+    expect(invade($browsershot)->additionalOptions['functionTimeout'])->toBe(5000);
+});
+
+it('does not configure a wait function when readiness is not requested', function () {
+    $driver = new BrowsershotDriver;
+
+    $browsershot = invade($driver)->buildBrowsershot('<p>hi</p>', null, null, new PdfOptions);
+
+    expect(invade($browsershot)->additionalOptions)->not->toHaveKey('function');
+});

--- a/tests/Unit/CacheBuilderTest.php
+++ b/tests/Unit/CacheBuilderTest.php
@@ -64,8 +64,8 @@ it('caches for a day by default', function () {
     expect(config('laravel-pdf.cache.ttl'))->toBe(60 * 60 * 24);
 });
 
-it('caches by default when enabled in config', function () {
-    config()->set('laravel-pdf.cache.enabled', true);
+it('caches automatically when enabled in config', function () {
+    config()->set('laravel-pdf.cache.automatic', true);
 
     $driver = new FakeDriver;
 
@@ -75,8 +75,8 @@ it('caches by default when enabled in config', function () {
     expect($driver->generateCount)->toBe(1);
 });
 
-it('can opt out of caching with dontCache when enabled in config', function () {
-    config()->set('laravel-pdf.cache.enabled', true);
+it('can opt out of automatic caching with dontCache', function () {
+    config()->set('laravel-pdf.cache.automatic', true);
 
     $driver = new FakeDriver;
 

--- a/tests/Unit/CacheBuilderTest.php
+++ b/tests/Unit/CacheBuilderTest.php
@@ -7,6 +7,8 @@ use Spatie\LaravelPdf\Facades\Pdf;
 use Spatie\LaravelPdf\PdfOptions;
 use Spatie\LaravelPdf\Tests\TestSupport\FakeDriver;
 
+use function Illuminate\Support\hours;
+
 beforeEach(function () {
     Cache::flush();
 });
@@ -114,10 +116,37 @@ it('uses the driver name in the cache fingerprint', function () {
     expect($first)->not->toBe($second);
 });
 
+it('accepts a carbon interval as a lifetime', function () {
+    $driver = new FakeDriver;
+
+    Pdf::html('<p>hi</p>')->setDriver($driver)->cache(hours(2))->base64();
+    Pdf::html('<p>hi</p>')->setDriver($driver)->cache(hours(2))->base64();
+
+    expect($driver->generateCount)->toBe(1);
+});
+
+it('accepts a date time as a lifetime', function () {
+    $driver = new FakeDriver;
+
+    Pdf::html('<p>hi</p>')->setDriver($driver)->cache(now()->addHour())->base64();
+    Pdf::html('<p>hi</p>')->setDriver($driver)->cache(now()->addHour())->base64();
+
+    expect($driver->generateCount)->toBe(1);
+});
+
+it('honors an expired lifetime by regenerating', function () {
+    $driver = new FakeDriver;
+
+    Pdf::html('<p>hi</p>')->setDriver($driver)->cache(now()->subMinute())->base64();
+    Pdf::html('<p>hi</p>')->setDriver($driver)->cache(now()->subMinute())->base64();
+
+    expect($driver->generateCount)->toBe(2);
+});
+
 it('uses the cache implementation bound in the container', function () {
     app()->instance(PdfCache::class, new class implements PdfCache
     {
-        public function remember(string $fingerprint, ?string $key, ?int $ttl, Closure $generate): string
+        public function remember(string $fingerprint, ?string $key, DateTimeInterface|DateInterval|int|null $ttl, Closure $generate): string
         {
             return 'overridden-content';
         }

--- a/tests/Unit/CacheBuilderTest.php
+++ b/tests/Unit/CacheBuilderTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use Illuminate\Support\Facades\Cache;
+use Spatie\LaravelPdf\Caching\PdfCache;
+use Spatie\LaravelPdf\Facades\Pdf;
+use Spatie\LaravelPdf\Tests\TestSupport\FakeDriver;
+
+beforeEach(function () {
+    Cache::flush();
+});
+
+it('does not cache by default', function () {
+    $driver = new FakeDriver;
+
+    Pdf::html('<p>hi</p>')->setDriver($driver)->base64();
+    Pdf::html('<p>hi</p>')->setDriver($driver)->base64();
+
+    expect($driver->generateCount)->toBe(2);
+});
+
+it('caches generated content across renders', function () {
+    $driver = new FakeDriver;
+
+    $first = Pdf::html('<p>hi</p>')->setDriver($driver)->cache()->base64();
+    $second = Pdf::html('<p>hi</p>')->setDriver($driver)->cache()->base64();
+
+    expect($driver->generateCount)->toBe(1);
+    expect($first)->toBe($second);
+});
+
+it('uses a separate cache entry when the html differs', function () {
+    $driver = new FakeDriver;
+
+    Pdf::html('<p>one</p>')->setDriver($driver)->cache()->base64();
+    Pdf::html('<p>two</p>')->setDriver($driver)->cache()->base64();
+
+    expect($driver->generateCount)->toBe(2);
+});
+
+it('shares a cache entry when a custom key is given', function () {
+    $driver = new FakeDriver;
+
+    Pdf::html('<p>one</p>')->setDriver($driver)->cache(null, 'shared')->base64();
+    Pdf::html('<p>two</p>')->setDriver($driver)->cache(null, 'shared')->base64();
+
+    expect($driver->generateCount)->toBe(1);
+});
+
+it('serves a cached pdf when saving to a path', function () {
+    $driver = new FakeDriver('%PDF-cached');
+    $path = getTempPath('cached.pdf');
+
+    Pdf::html('<p>hi</p>')->setDriver($driver)->cache()->save($path);
+    Pdf::html('<p>hi</p>')->setDriver($driver)->cache()->save($path);
+
+    expect($driver->generateCount)->toBe(1);
+    expect($driver->saveCount)->toBe(0);
+    expect(file_get_contents($path))->toBe('%PDF-cached');
+});
+
+it('uses the cache implementation bound in the container', function () {
+    app()->instance(PdfCache::class, new class implements PdfCache
+    {
+        public function remember(string $fingerprint, ?string $key, ?int $ttl, Closure $generate): string
+        {
+            return 'overridden-content';
+        }
+    });
+
+    $driver = new FakeDriver;
+
+    $content = Pdf::html('<p>hi</p>')->setDriver($driver)->cache()->base64();
+
+    expect(base64_decode($content))->toBe('overridden-content');
+    expect($driver->generateCount)->toBe(0);
+});

--- a/tests/Unit/CacheBuilderTest.php
+++ b/tests/Unit/CacheBuilderTest.php
@@ -58,6 +58,32 @@ it('serves a cached pdf when saving to a path', function () {
     expect(file_get_contents($path))->toBe('%PDF-cached');
 });
 
+it('caches for a day by default', function () {
+    expect(config('laravel-pdf.cache.ttl'))->toBe(60 * 60 * 24);
+});
+
+it('caches by default when enabled in config', function () {
+    config()->set('laravel-pdf.cache.enabled', true);
+
+    $driver = new FakeDriver;
+
+    Pdf::html('<p>hi</p>')->setDriver($driver)->base64();
+    Pdf::html('<p>hi</p>')->setDriver($driver)->base64();
+
+    expect($driver->generateCount)->toBe(1);
+});
+
+it('can opt out of caching with dontCache when enabled in config', function () {
+    config()->set('laravel-pdf.cache.enabled', true);
+
+    $driver = new FakeDriver;
+
+    Pdf::html('<p>hi</p>')->setDriver($driver)->dontCache()->base64();
+    Pdf::html('<p>hi</p>')->setDriver($driver)->dontCache()->base64();
+
+    expect($driver->generateCount)->toBe(2);
+});
+
 it('uses the cache implementation bound in the container', function () {
     app()->instance(PdfCache::class, new class implements PdfCache
     {

--- a/tests/Unit/CacheBuilderTest.php
+++ b/tests/Unit/CacheBuilderTest.php
@@ -1,13 +1,12 @@
 <?php
 
+use Carbon\CarbonInterval;
 use Illuminate\Support\Facades\Cache;
 use Spatie\LaravelPdf\Caching\PdfCache;
 use Spatie\LaravelPdf\Exceptions\CouldNotGeneratePdf;
 use Spatie\LaravelPdf\Facades\Pdf;
 use Spatie\LaravelPdf\PdfOptions;
 use Spatie\LaravelPdf\Tests\TestSupport\FakeDriver;
-
-use function Illuminate\Support\hours;
 
 beforeEach(function () {
     Cache::flush();
@@ -119,8 +118,8 @@ it('uses the driver name in the cache fingerprint', function () {
 it('accepts a carbon interval as a lifetime', function () {
     $driver = new FakeDriver;
 
-    Pdf::html('<p>hi</p>')->setDriver($driver)->cache(hours(2))->base64();
-    Pdf::html('<p>hi</p>')->setDriver($driver)->cache(hours(2))->base64();
+    Pdf::html('<p>hi</p>')->setDriver($driver)->cache(CarbonInterval::hours(2))->base64();
+    Pdf::html('<p>hi</p>')->setDriver($driver)->cache(CarbonInterval::hours(2))->base64();
 
     expect($driver->generateCount)->toBe(1);
 });

--- a/tests/Unit/CacheBuilderTest.php
+++ b/tests/Unit/CacheBuilderTest.php
@@ -2,7 +2,9 @@
 
 use Illuminate\Support\Facades\Cache;
 use Spatie\LaravelPdf\Caching\PdfCache;
+use Spatie\LaravelPdf\Exceptions\CouldNotGeneratePdf;
 use Spatie\LaravelPdf\Facades\Pdf;
+use Spatie\LaravelPdf\PdfOptions;
 use Spatie\LaravelPdf\Tests\TestSupport\FakeDriver;
 
 beforeEach(function () {
@@ -82,6 +84,34 @@ it('can opt out of caching with dontCache when enabled in config', function () {
     Pdf::html('<p>hi</p>')->setDriver($driver)->dontCache()->base64();
 
     expect($driver->generateCount)->toBe(2);
+});
+
+it('throws when caching a pdf customized with a browsershot closure', function () {
+    Pdf::html('<p>hi</p>')
+        ->setDriver(new FakeDriver)
+        ->withBrowsershot(fn () => null)
+        ->cache()
+        ->base64();
+})->throws(CouldNotGeneratePdf::class);
+
+it('allows caching a browsershot-customized pdf when an explicit key is given', function () {
+    $content = Pdf::html('<p>hi</p>')
+        ->setDriver(new FakeDriver)
+        ->withBrowsershot(fn () => null)
+        ->cache(key: 'explicit')
+        ->base64();
+
+    expect(base64_decode($content))->toBe('%PDF-fake');
+});
+
+it('uses the driver name in the cache fingerprint', function () {
+    $first = invade(Pdf::html('<p>hi</p>')->driver('browsershot'))
+        ->cacheFingerprint('<p>hi</p>', null, null, new PdfOptions);
+
+    $second = invade(Pdf::html('<p>hi</p>')->driver('chrome'))
+        ->cacheFingerprint('<p>hi</p>', null, null, new PdfOptions);
+
+    expect($first)->not->toBe($second);
 });
 
 it('uses the cache implementation bound in the container', function () {

--- a/tests/Unit/DefaultPdfCacheTest.php
+++ b/tests/Unit/DefaultPdfCacheTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use Illuminate\Support\Facades\Cache;
+use Spatie\LaravelPdf\Caching\DefaultPdfCache;
+use Spatie\LaravelPdf\Caching\PdfCache;
+
+beforeEach(function () {
+    Cache::flush();
+});
+
+it('is the default binding for the PdfCache contract', function () {
+    expect(app(PdfCache::class))->toBeInstanceOf(DefaultPdfCache::class);
+});
+
+it('generates content on a miss and reuses it on a hit', function () {
+    $cache = new DefaultPdfCache;
+    $calls = 0;
+
+    $generate = function () use (&$calls) {
+        $calls++;
+
+        return "%PDF-{$calls}";
+    };
+
+    $first = $cache->remember('fingerprint-a', null, null, $generate);
+    $second = $cache->remember('fingerprint-a', null, null, $generate);
+
+    expect($first)->toBe('%PDF-1');
+    expect($second)->toBe('%PDF-1');
+    expect($calls)->toBe(1);
+});
+
+it('uses a separate entry for a different fingerprint', function () {
+    $cache = new DefaultPdfCache;
+    $calls = 0;
+    $generate = function () use (&$calls) {
+        $calls++;
+
+        return "%PDF-{$calls}";
+    };
+
+    $cache->remember('fingerprint-a', null, null, $generate);
+    $cache->remember('fingerprint-b', null, null, $generate);
+
+    expect($calls)->toBe(2);
+});
+
+it('shares one entry across fingerprints when a custom key is given', function () {
+    $cache = new DefaultPdfCache;
+    $calls = 0;
+    $generate = function () use (&$calls) {
+        $calls++;
+
+        return "%PDF-{$calls}";
+    };
+
+    $cache->remember('fingerprint-a', 'shared-key', null, $generate);
+    $cache->remember('fingerprint-b', 'shared-key', null, $generate);
+
+    expect($calls)->toBe(1);
+});
+
+it('round-trips binary content without corruption', function () {
+    $cache = new DefaultPdfCache;
+    $binary = random_bytes(2048);
+
+    $result = $cache->remember('binary', null, null, fn () => $binary);
+
+    expect($result)->toBe($binary);
+});
+
+it('stores the content under the configured prefix', function () {
+    config()->set('laravel-pdf.cache.prefix', 'custom-prefix');
+
+    $cache = new DefaultPdfCache;
+    $cache->remember('fingerprint-a', null, null, fn () => '%PDF');
+
+    expect(Cache::has('custom-prefix:'.sha1('fingerprint-a')))->toBeTrue();
+});

--- a/tests/Unit/ReadinessTest.php
+++ b/tests/Unit/ReadinessTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use Spatie\LaravelPdf\Exceptions\CouldNotGeneratePdf;
+use Spatie\LaravelPdf\Facades\Pdf;
+use Spatie\LaravelPdf\Tests\TestSupport\FakeDriver;
+
+it('does not wait for readiness by default', function () {
+    $builder = Pdf::html('<p>hi</p>');
+
+    $options = invade($builder)->buildOptions();
+
+    expect($options->waitForReady)->toBeNull();
+});
+
+it('waits for the default readiness flag', function () {
+    $builder = Pdf::html('<p>hi</p>')->waitUntilReady();
+
+    $options = invade($builder)->buildOptions();
+
+    expect($options->waitForReady)->toBe('window.pdfReady === true');
+});
+
+it('waits for a custom readiness expression with a timeout', function () {
+    $builder = Pdf::html('<p>hi</p>')->waitUntilReady('window.ready', 5000);
+
+    $options = invade($builder)->buildOptions();
+
+    expect($options->waitForReady)->toBe('window.ready');
+    expect($options->waitForReadyTimeout)->toBe(5000);
+});
+
+it('passes the readiness expression to a supporting driver', function () {
+    $driver = new FakeDriver;
+
+    Pdf::html('<p>hi</p>')->setDriver($driver)->waitUntilReady()->base64();
+
+    expect($driver->lastOptions->waitForReady)->toBe('window.pdfReady === true');
+});
+
+it('throws when the active driver does not support readiness', function () {
+    Pdf::html('<p>hi</p>')->driver('dompdf')->waitUntilReady()->base64();
+})->throws(CouldNotGeneratePdf::class, 'does not support waiting for readiness');

--- a/workbench/resources/views/readiness.blade.php
+++ b/workbench/resources/views/readiness.blade.php
@@ -1,0 +1,8 @@
+<div id="target">loading</div>
+
+<script>
+    setTimeout(() => {
+        document.getElementById('target').innerHTML = 'ready for capture';
+        window.pdfReady = true;
+    }, 500);
+</script>


### PR DESCRIPTION
This PR adds two features inspired by gaps relative to other Chromium-based PDF packages.

## Waiting for readiness

JavaScript heavy views (charts, maps, web fonts, async data) can be captured before they finish rendering. Instead of guessing with arbitrary delays, you can now wait for an explicit readiness signal.

```php
Pdf::view('pdf.report')
    ->waitUntilReady() // waits for window.pdfReady === true
    ->save('report.pdf');
```

You set `window.pdfReady = true` in your view once everything is done. A custom JavaScript expression and a timeout are supported:

```php
Pdf::view('pdf.report')
    ->waitUntilReady('window.charts.every(chart => chart.rendered)', timeout: 5000)
    ->save('report.pdf');
```

Supported on the Browsershot and Chrome drivers via a `SupportsReadiness` marker interface. Calling `waitUntilReady()` while a driver that cannot run JavaScript is active (DOMPDF, WeasyPrint) throws a clear `CouldNotGeneratePdf` exception.

## Render caching

Rendering through a Chromium-based driver is expensive. Calling `cache()` stores the rendered result so identical renders are served from the cache.

```php
Pdf::view('pdf.invoice', ['invoice' => $invoice])
    ->cache() // one day, auto key
    ->download('invoice.pdf');

Pdf::view('pdf.invoice', ['invoice' => $invoice])
    ->cache(3600, "invoice-{$invoice->id}") // ttl + custom key
    ->save('invoice.pdf');
```

Caching can also be enabled globally so every PDF is cached without calling `cache()`. Set `cache.enabled` to `true` in the config (or `LARAVEL_PDF_CACHE_ENABLED=true`). With it on, `cache()` still overrides the lifetime and key per PDF, and `dontCache()` skips the cache for a single render. The default lifetime is one day.

The default cache key is derived from the rendered HTML, header, footer, formatting options, metadata, and encryption settings, so renders that differ in any of these never collide. All caching behaviour lives in a swappable `PdfCache` implementation, configurable through the new `cache` config block (enabled, store, prefix, ttl, and class). The default implementation base64 encodes content before storing so binary unsafe cache stores cannot corrupt the PDF.

Caching applies to synchronous generation. Queued generation is not cached.

## Notes

* New unit and integration tests cover both features. The readiness integration test verifies that delayed content is absent without `waitUntilReady()` and present with it.
* Docs added under `docs/advanced-usage`.
* Readiness for the remote Chromium drivers (Cloudflare, Gotenberg) is intentionally out of scope here and can follow later.