### PR TITLE
Add readiness support to the Gotenberg driver

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -62,7 +62,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install poppler-utils
-        run: sudo apt-get install -y poppler-utils
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y poppler-utils
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/docs/advanced-usage/waiting-for-readiness.md
+++ b/docs/advanced-usage/waiting-for-readiness.md
@@ -55,6 +55,8 @@ Pdf::view('pdf.report')
 
 ## Driver support
 
-Waiting for readiness requires a driver that can execute JavaScript. It is supported by the [Browsershot](/docs/laravel-pdf/v2/drivers/customizing-browsershot) and [Chrome](/docs/laravel-pdf/v2/drivers/using-the-chrome-driver) drivers.
+Waiting for readiness requires a driver that can execute JavaScript. It is supported by the [Browsershot](/docs/laravel-pdf/v2/drivers/customizing-browsershot), [Chrome](/docs/laravel-pdf/v2/drivers/using-the-chrome-driver), and [Gotenberg](/docs/laravel-pdf/v2/drivers/using-the-gotenberg-driver) drivers.
+
+When using Gotenberg, the readiness expression is passed as its `waitForExpression` field, and the timeout is applied to the HTTP request so it does not abort before Gotenberg finishes rendering.
 
 Calling `waitUntilReady()` while a driver that cannot run JavaScript is active (such as DOMPDF or WeasyPrint) throws a `CouldNotGeneratePdf` exception.

--- a/docs/drivers/using-the-gotenberg-driver.md
+++ b/docs/drivers/using-the-gotenberg-driver.md
@@ -55,6 +55,21 @@ The Gotenberg driver supports the following PDF options:
 - `tagged()` — Generate tagged (accessible) PDF
 - `headerView()` / `headerHtml()` — Page headers (repeated on every page)
 - `footerView()` / `footerHtml()` — Page footers (repeated on every page)
+- `waitUntilReady()` — Wait for a JavaScript readiness signal before capturing (see [Waiting for readiness](/docs/laravel-pdf/v2/advanced-usage/waiting-for-readiness))
+
+## Waiting for readiness
+
+Because Gotenberg renders with headless Chromium, it can wait for a JavaScript expression to become truthy before capturing the PDF. Call `waitUntilReady()` on the builder to defer capturing until your view signals it is done rendering:
+
+```php
+use Spatie\LaravelPdf\Facades\Pdf;
+
+Pdf::view('pdfs.report', ['report' => $report])
+    ->waitUntilReady()
+    ->save('report.pdf');
+```
+
+The readiness expression is sent to Gotenberg as its `waitForExpression` field. The timeout you pass to `waitUntilReady()` (30 seconds by default) is also applied to the HTTP request, so the request does not abort before Gotenberg finishes rendering. See [Waiting for readiness](/docs/laravel-pdf/v2/advanced-usage/waiting-for-readiness) for the full details.
 
 ## Headers and footers
 

--- a/src/Drivers/GotenbergDriver.php
+++ b/src/Drivers/GotenbergDriver.php
@@ -8,7 +8,7 @@ use Spatie\LaravelPdf\Enums\Orientation;
 use Spatie\LaravelPdf\Exceptions\CouldNotGeneratePdf;
 use Spatie\LaravelPdf\PdfOptions;
 
-class GotenbergDriver implements PdfDriver
+class GotenbergDriver implements PdfDriver, SupportsReadiness
 {
     protected string $url;
 
@@ -69,6 +69,12 @@ class GotenbergDriver implements PdfDriver
                 fn (PendingRequest $request): PendingRequest => $request->withBasicAuth(
                     $this->username,
                     $this->password
+                )
+            )
+            ->when(
+                $options->waitForReady !== null,
+                fn (PendingRequest $request): PendingRequest => $request->timeout(
+                    (int) ceil(($options->waitForReadyTimeout ?? 30000) / 1000)
                 )
             );
 
@@ -132,6 +138,10 @@ class GotenbergDriver implements PdfDriver
 
         if ($options->tagged) {
             $fields['generateTaggedPdf'] = 'true';
+        }
+
+        if ($options->waitForReady !== null) {
+            $fields['waitForExpression'] = $options->waitForReady;
         }
 
         return $fields;

--- a/tests/Integration/GotenbergIntegrationTest.php
+++ b/tests/Integration/GotenbergIntegrationTest.php
@@ -35,6 +35,30 @@ it('generates a pdf with default options', function () {
     expect($result)->toStartWith('%PDF');
 });
 
+it('waits for a readiness expression before capturing', function () {
+    $html = <<<'HTML'
+    <html>
+    <body>
+        <h1 id="status">loading</h1>
+        <script>
+            setTimeout(() => {
+                document.getElementById('status').textContent = 'ready';
+                window.pdfReady = true;
+            }, 250);
+        </script>
+    </body>
+    </html>
+    HTML;
+
+    $options = new PdfOptions;
+    $options->waitForReady = 'window.pdfReady === true';
+    $options->waitForReadyTimeout = 10000;
+
+    $result = $this->driver->generatePdf($html, null, null, $options);
+
+    expect($result)->toStartWith('%PDF');
+});
+
 it('saves a pdf to disk', function () {
     $path = getTempPath('gotenberg-save-test.pdf');
     $this->driver->savePdf('<h1>Hello</h1>', null, null, new PdfOptions, $path);

--- a/tests/Unit/GotenbergDriverTest.php
+++ b/tests/Unit/GotenbergDriverTest.php
@@ -222,8 +222,53 @@ it('does not send optional fields when not set', function () {
             && ! $names->contains('nativePageRanges')
             && ! $names->contains('generateTaggedPdf')
             && ! $names->contains('landscape')
-            && ! $names->contains('paperWidth');
+            && ! $names->contains('paperWidth')
+            && ! $names->contains('waitForExpression');
     });
+});
+
+it('sends the readiness expression as waitForExpression', function () {
+    Http::fake([
+        'localhost:3000/*' => Http::response('fake-pdf', 200),
+    ]);
+
+    $driver = new GotenbergDriver(['url' => 'http://localhost:3000']);
+
+    $options = new PdfOptions;
+    $options->waitForReady = 'window.pdfReady === true';
+
+    $driver->generatePdf('<h1>Hello</h1>', null, null, $options);
+
+    Http::assertSent(function ($request) {
+        return collect($request->data())->contains(
+            fn ($part) => ($part['name'] ?? null) === 'waitForExpression'
+                && $part['contents'] === 'window.pdfReady === true'
+        );
+    });
+});
+
+it('sets the request timeout from the readiness timeout', function () {
+    $driver = new GotenbergDriver(['url' => 'http://localhost:3000']);
+
+    $options = new PdfOptions;
+    $options->waitForReady = 'window.pdfReady === true';
+    $options->waitForReadyTimeout = 60000;
+
+    $request = invade($driver)->buildRequest('<h1>Hello</h1>', null, null, $options);
+
+    expect(invade($request)->options['timeout'])->toBe(60);
+});
+
+it('rounds a sub-second readiness timeout up to a whole second', function () {
+    $driver = new GotenbergDriver(['url' => 'http://localhost:3000']);
+
+    $options = new PdfOptions;
+    $options->waitForReady = 'window.pdfReady === true';
+    $options->waitForReadyTimeout = 4500;
+
+    $request = invade($driver)->buildRequest('<h1>Hello</h1>', null, null, $options);
+
+    expect(invade($request)->options['timeout'])->toBe(5);
 });
 
 it('sends header and footer as html files', function () {


### PR DESCRIPTION
Closes the request in discussion #349.

The Gotenberg driver now implements `SupportsReadiness`, so `waitUntilReady()` works with it just like the Browsershot and Chrome drivers.

## What changed

- `GotenbergDriver` implements `SupportsReadiness`, so calling `waitUntilReady()` while Gotenberg is active no longer throws `CouldNotGeneratePdf`.
- When a readiness expression is set, it is passed to Gotenberg as its `waitForExpression` form field.
- When waiting for readiness, the readiness timeout (`waitForReadyTimeout`, default 30000ms) is applied to the HTTP request via `->timeout()`. Without this, the request keeps the default 30s curl timeout and can abort before Gotenberg finishes rendering a slow view.

```php
use Spatie\LaravelPdf\Facades\Pdf;

Pdf::view('pdfs.report', ['report' => $report])
    ->waitUntilReady()
    ->save('report.pdf');
```

## A note on `waitDelay`

The discussion suggested also setting Gotenberg's `waitDelay` to the timeout. I left that out on purpose: `waitDelay` is an unconditional sleep, so setting it to 30000ms would force every readiness request to wait the full timeout even when the expression resolves immediately. As the discussion notes, Gotenberg ignores `waitDelay` when `waitForExpression` is set anyway. The real fix is the HTTP client timeout, which is what is applied here.

## Tests

Added unit tests covering the `waitForExpression` field and the request timeout (including sub-second rounding), and an integration test that renders a view which flips `window.pdfReady` after a delay and confirms a PDF is produced. Docs updated for the readiness and Gotenberg driver pages.