### PR TITLE
Document BladePDF community driver

### DIFF
--- a/docs/drivers/custom-drivers.md
+++ b/docs/drivers/custom-drivers.md
@@ -92,3 +92,9 @@ $this->app->singleton(PdfDriver::class, function () {
     return new WeasyPrintDriver(config('laravel-pdf.weasyprint', []));
 });
 ```
+
+## Community drivers
+
+The following custom drivers are maintained by the community and are not officially supported by Spatie:
+
+- [`bladepdf/spatie-laravel-pdf-driver`](https://github.com/bladepdf/spatie-laravel-pdf-driver) — renders PDFs using BladePDF's managed Chromium API. A BladePDF account and API key are required.


### PR DESCRIPTION
This adds a small Community drivers section to the custom driver documentation
and lists the BladePDF adapter discussed in
https://github.com/spatie/laravel-pdf/discussions/361.

The driver is available on GitHub and Packagist:

- https://github.com/bladepdf/spatie-laravel-pdf-driver
- https://packagist.org/packages/bladepdf/spatie-laravel-pdf-driver

This is a documentation-only change.