### PR TITLE
Added document outline option to PDF driver

### DIFF
--- a/docs/basic-usage/formatting-pdfs.md
+++ b/docs/basic-usage/formatting-pdfs.md
@@ -240,6 +240,20 @@ Pdf::view('pdf.invoice', ['invoice' => $invoice])
 
 > Tagged PDFs are supported by the Browsershot and Cloudflare drivers. The DOMPDF driver does not support this option.
 
+## Document outline
+
+You can generate a document outline (bookmarks) using the `documentOutline` method. The outline is built from the headings in your view, and lets readers jump to a section from the sidebar of their PDF viewer.
+
+```php
+use Spatie\LaravelPdf\Facades\Pdf;
+
+Pdf::view('pdf.report', ['report' => $report])
+    ->documentOutline()
+    ->save('/some/directory/report.pdf');
+```
+
+> Document outlines are supported by the Browsershot, Cloudflare and Gotenberg drivers. The DOMPDF, Chrome and WeasyPrint drivers do not support this option.
+
 ## PDF metadata
 
 You can set PDF document metadata such as title, author, subject, and keywords using the `meta` method. This metadata is displayed in PDF viewers — for example, the title is shown in the browser tab when viewing a PDF inline.

--- a/docs/drivers/using-the-chrome-driver.md
+++ b/docs/drivers/using-the-chrome-driver.md
@@ -96,4 +96,4 @@ Pdf::view('pdfs.invoice', ['invoice' => $invoice])
 - The Chrome driver requires both the `chrome-php/chrome` package and a local Chrome or Chromium executable. It does not download or bundle a browser for you.
 - In Docker or other locked-down environments, you may need to enable `no_sandbox`.
 - This driver only documents and exposes the options supported by Laravel PDF. If you need deeper Chromium customization, use the Browsershot driver instead.
-- The `tagged()`, `withBrowsershot()` and `onLambda()` methods have no effect when using the Chrome driver.
+- The `tagged()`, `documentOutline()`, `withBrowsershot()` and `onLambda()` methods have no effect when using the Chrome driver.

--- a/docs/drivers/using-the-cloudflare-driver.md
+++ b/docs/drivers/using-the-cloudflare-driver.md
@@ -41,6 +41,8 @@ The Cloudflare driver supports the following PDF options:
 - `format()` — Paper format (a4, letter, etc.)
 - `paperSize()` — Custom paper dimensions
 - `margins()` — Page margins
+- `tagged()` — Generate tagged (accessible) PDF
+- `documentOutline()` — Generate a document outline (bookmarks)
 - `landscape()` / `orientation()` — Page orientation
 - `headerView()` / `headerHtml()` — Page headers
 - `footerView()` / `footerHtml()` — Page footers

--- a/docs/drivers/using-the-gotenberg-driver.md
+++ b/docs/drivers/using-the-gotenberg-driver.md
@@ -53,6 +53,7 @@ The Gotenberg driver supports the following PDF options:
 - `scale()` — Page rendering scale
 - `pageRanges()` — Specific pages to include
 - `tagged()` — Generate tagged (accessible) PDF
+- `documentOutline()` — Generate a document outline (bookmarks)
 - `headerView()` / `headerHtml()` — Page headers (repeated on every page)
 - `footerView()` / `footerHtml()` — Page footers (repeated on every page)
 - `waitUntilReady()` — Wait for a JavaScript readiness signal before capturing (see [Waiting for readiness](/docs/laravel-pdf/v2/advanced-usage/waiting-for-readiness))

--- a/src/Drivers/BrowsershotDriver.php
+++ b/src/Drivers/BrowsershotDriver.php
@@ -112,12 +112,12 @@ class BrowsershotDriver implements PdfDriver, SupportsReadiness
             $browsershot->taggedPdf();
         }
 
-        if ($options->waitForReady !== null) {
-            $browsershot->waitForFunction($options->waitForReady, null, $options->waitForReadyTimeout ?? 30000);
+        if ($options->documentOutline) {
+            $browsershot->setOption('outline', true);
         }
 
-        if ($options->documentOutline === true) {
-            $browsershot->setOption('outline', true);
+        if ($options->waitForReady !== null) {
+            $browsershot->waitForFunction($options->waitForReady, null, $options->waitForReadyTimeout ?? 30000);
         }
 
         $this->applyConfigurationDefaults($browsershot);

--- a/src/Drivers/BrowsershotDriver.php
+++ b/src/Drivers/BrowsershotDriver.php
@@ -116,6 +116,10 @@ class BrowsershotDriver implements PdfDriver, SupportsReadiness
             $browsershot->waitForFunction($options->waitForReady, null, $options->waitForReadyTimeout ?? 30000);
         }
 
+        if ($options->documentOutline === true) {
+            $browsershot->setOption('outline', true);
+        }
+
         $this->applyConfigurationDefaults($browsershot);
 
         if ($this->customizeBrowsershot) {

--- a/src/Drivers/CloudflareDriver.php
+++ b/src/Drivers/CloudflareDriver.php
@@ -94,6 +94,10 @@ class CloudflareDriver implements PdfDriver
             $pdfOptions['tagged'] = true;
         }
 
+        if ($options->documentOutline) {
+            $pdfOptions['outline'] = true;
+        }
+
         if ($headerHtml || $footerHtml) {
             $pdfOptions['displayHeaderFooter'] = true;
 

--- a/src/Drivers/GotenbergDriver.php
+++ b/src/Drivers/GotenbergDriver.php
@@ -144,6 +144,10 @@ class GotenbergDriver implements PdfDriver, SupportsReadiness
             $fields['waitForExpression'] = $options->waitForReady;
         }
 
+        if ($options->documentOutline === true) {
+            $fields['generateDocumentOutline'] = $options->documentOutline;
+        }
+
         return $fields;
     }
 }

--- a/src/Drivers/GotenbergDriver.php
+++ b/src/Drivers/GotenbergDriver.php
@@ -140,12 +140,12 @@ class GotenbergDriver implements PdfDriver, SupportsReadiness
             $fields['generateTaggedPdf'] = 'true';
         }
 
-        if ($options->waitForReady !== null) {
-            $fields['waitForExpression'] = $options->waitForReady;
+        if ($options->documentOutline) {
+            $fields['generateDocumentOutline'] = 'true';
         }
 
-        if ($options->documentOutline === true) {
-            $fields['generateDocumentOutline'] = $options->documentOutline;
+        if ($options->waitForReady !== null) {
+            $fields['waitForExpression'] = $options->waitForReady;
         }
 
         return $fields;

--- a/src/PdfBuilder.php
+++ b/src/PdfBuilder.php
@@ -69,6 +69,8 @@ class PdfBuilder implements Attachable, Responsable
 
     public bool $tagged = false;
 
+    public bool $documentOutline = false;
+
     public ?string $waitForReady = null;
 
     public ?int $waitForReadyTimeout = null;
@@ -332,6 +334,13 @@ class PdfBuilder implements Attachable, Responsable
         return $this;
     }
 
+    public function documentOutline(): self
+    {
+        $this->documentOutline = true;
+
+        return $this;
+    }
+
     public function waitUntilReady(?string $expression = null, ?int $timeout = null): self
     {
         $this->waitForReady = $expression ?? 'window.pdfReady === true';
@@ -577,6 +586,7 @@ class PdfBuilder implements Attachable, Responsable
         $options->scale = $this->scale;
         $options->pageRanges = $this->pageRanges;
         $options->tagged = $this->tagged;
+        $options->documentOutline = $this->documentOutline;
         $options->encryption = $this->encryption;
         $options->waitForReady = $this->waitForReady;
         $options->waitForReadyTimeout = $this->waitForReadyTimeout;

--- a/src/PdfOptions.php
+++ b/src/PdfOptions.php
@@ -25,4 +25,6 @@ class PdfOptions
     public ?string $waitForReady = null;
 
     public ?int $waitForReadyTimeout = null;
+
+    public bool $documentOutline = false;
 }

--- a/tests/Unit/CloudflareDriverTest.php
+++ b/tests/Unit/CloudflareDriverTest.php
@@ -239,6 +239,26 @@ it('sends tagged option to cloudflare', function () {
     });
 });
 
+it('sends document outline option to cloudflare', function () {
+    Http::fake([
+        'api.cloudflare.com/*' => Http::response('fake-pdf', 200),
+    ]);
+
+    $driver = new CloudflareDriver([
+        'api_token' => 'test-token',
+        'account_id' => 'test-account',
+    ]);
+
+    $options = new PdfOptions;
+    $options->documentOutline = true;
+
+    $driver->generatePdf('<h1>Hello</h1>', null, null, $options);
+
+    Http::assertSent(function ($request) {
+        return $request['pdfOptions']['outline'] === true;
+    });
+});
+
 it('does not send scale or page ranges when not set', function () {
     Http::fake([
         'api.cloudflare.com/*' => Http::response('fake-pdf', 200),

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -133,6 +133,17 @@ it('applies tagged pdf option to browsershot', function () {
     expect(invade($browsershot)->taggedPdf)->toBeTrue();
 });
 
+it('applies document outline option to browsershot', function () {
+    $driver = new BrowsershotDriver;
+
+    $options = new PdfOptions;
+    $options->documentOutline = true;
+
+    $browsershot = invade($driver)->buildBrowsershot('test', null, null, $options);
+
+    expect(getBrowsershotOption($browsershot, 'outline'))->toBeTrue();
+});
+
 function getBrowsershotOption(object $browsershot, string $key): mixed
 {
     $options = invade($browsershot)->additionalOptions;

--- a/tests/Unit/FakePdfTest.php
+++ b/tests/Unit/FakePdfTest.php
@@ -274,6 +274,16 @@ it('can determine that tagged was set on a saved pdf', function () {
     });
 });
 
+it('can determine that a document outline was set on a saved pdf', function () {
+    Pdf::view('test')
+        ->documentOutline()
+        ->save('outline.pdf');
+
+    Pdf::assertSaved(function (PdfBuilder $pdf) {
+        return $pdf->documentOutline === true;
+    });
+});
+
 it('can determine that metadata was set on a pdf response', function () {
     Route::get('pdf', function () {
         return pdf('test')

--- a/tests/Unit/GotenbergDriverTest.php
+++ b/tests/Unit/GotenbergDriverTest.php
@@ -186,6 +186,25 @@ it('sends page ranges option to gotenberg', function () {
     });
 });
 
+it('sends document outline option to gotenberg', function () {
+    Http::fake([
+        'localhost:3000/*' => Http::response('fake-pdf', 200),
+    ]);
+
+    $driver = new GotenbergDriver(['url' => 'http://localhost:3000']);
+
+    $options = new PdfOptions;
+    $options->documentOutline = true;
+
+    $driver->generatePdf('<h1>Hello</h1>', null, null, $options);
+
+    Http::assertSent(function ($request) {
+        return collect($request->data())->contains(
+            fn ($part) => ($part['name'] ?? null) === 'generateDocumentOutline' && $part['contents'] === 'true'
+        );
+    });
+});
+
 it('sends tagged option to gotenberg', function () {
     Http::fake([
         'localhost:3000/*' => Http::response('fake-pdf', 200),


### PR DESCRIPTION
I needed the `generageDocumentOutline` option in the Gotenberg driver. As it is an supported PDF option in multiple drivers I've added it to the PDF options.